### PR TITLE
feat: render with x11 on linux wayland

### DIFF
--- a/src-tauri/src/cmds/common.rs
+++ b/src-tauri/src/cmds/common.rs
@@ -191,14 +191,7 @@ pub async fn set_tray_visible(app_handle: tauri::AppHandle, visible: bool) -> Ap
 
 #[tauri::command]
 pub fn is_wayland() -> AppResult<bool> {
-    if cfg!(target_os = "linux") {
-        let session_type = std::env::var("XDG_SESSION_TYPE")
-            .unwrap_or("".to_string())
-            .to_lowercase();
-        Ok(session_type == "wayland")
-    } else {
-        Ok(false)
-    }
+    Ok(utils::unix_helper::is_wayland())
 }
 
 #[tauri::command]

--- a/src-tauri/src/feat.rs
+++ b/src-tauri/src/feat.rs
@@ -11,7 +11,6 @@ use crate::core::*;
 use crate::error::AppError;
 use crate::error::AppResult;
 use crate::log_err;
-// use crate::utils;
 use crate::utils::help;
 use crate::utils::resolve;
 use rust_i18n::t;

--- a/src-tauri/src/feat.rs
+++ b/src-tauri/src/feat.rs
@@ -11,6 +11,7 @@ use crate::core::*;
 use crate::error::AppError;
 use crate::error::AppResult;
 use crate::log_err;
+// use crate::utils;
 use crate::utils::help;
 use crate::utils::resolve;
 use rust_i18n::t;
@@ -374,29 +375,29 @@ pub async fn patch_clash(patch: Mapping) -> AppResult<()> {
 
 /// 修改verge的订阅
 /// 一般都是一个个的修改
-pub async fn patch_verge(mut patch: IVerge) -> AppResult<()> {
+pub async fn patch_verge(patch: IVerge) -> AppResult<()> {
     // handle window size when toggle system title bar enable on linux wayland
-    let enable_system_title_bar = patch.enable_system_title_bar;
-    if let Some(system_title_bar) = enable_system_title_bar
-        && cmds::common::is_wayland().unwrap_or(false)
-    {
-        tracing::debug!("calc windows size on linux wayland");
-        let verge_size_position = Config::verge().latest().window_size_position.clone();
-        if let Some(size_position) = verge_size_position {
-            let mut w = size_position[0];
-            let mut h = size_position[1];
-            let x = size_position[2];
-            let y = size_position[3];
-            if system_title_bar {
-                w += 90.;
-                h += 90.;
-            } else {
-                w -= 90.;
-                h -= 90.;
-            }
-            patch.window_size_position = Some(vec![w, h, x, y]);
-        }
-    }
+    // let enable_system_title_bar = patch.enable_system_title_bar;
+    // if let Some(system_title_bar) = enable_system_title_bar
+    //     && utils::unix_helper::is_wayland()
+    // {
+    //     tracing::debug!("calc windows size on linux wayland");
+    //     let verge_size_position = Config::verge().latest().window_size_position.clone();
+    //     if let Some(size_position) = verge_size_position {
+    //         let mut w = size_position[0];
+    //         let mut h = size_position[1];
+    //         let x = size_position[2];
+    //         let y = size_position[3];
+    //         if system_title_bar {
+    //             w += 90.;
+    //             h += 90.;
+    //         } else {
+    //             w -= 90.;
+    //             h -= 90.;
+    //         }
+    //         patch.window_size_position = Some(vec![w, h, x, y]);
+    //     }
+    // }
 
     tracing::debug!("patch verge draft");
     Config::verge().draft().patch_config(patch.clone());

--- a/src-tauri/src/feat.rs
+++ b/src-tauri/src/feat.rs
@@ -376,34 +376,107 @@ pub async fn patch_clash(patch: Mapping) -> AppResult<()> {
 /// 修改verge的订阅
 /// 一般都是一个个的修改
 pub async fn patch_verge(patch: IVerge) -> AppResult<()> {
-    // handle window size when toggle system title bar enable on linux wayland
-    // let enable_system_title_bar = patch.enable_system_title_bar;
-    // if let Some(system_title_bar) = enable_system_title_bar
-    //     && utils::unix_helper::is_wayland()
-    // {
-    //     tracing::debug!("calc windows size on linux wayland");
-    //     let verge_size_position = Config::verge().latest().window_size_position.clone();
-    //     if let Some(size_position) = verge_size_position {
-    //         let mut w = size_position[0];
-    //         let mut h = size_position[1];
-    //         let x = size_position[2];
-    //         let y = size_position[3];
-    //         if system_title_bar {
-    //             w += 90.;
-    //             h += 90.;
-    //         } else {
-    //             w -= 90.;
-    //             h -= 90.;
-    //         }
-    //         patch.window_size_position = Some(vec![w, h, x, y]);
-    //     }
-    // }
-
     tracing::debug!("patch verge draft");
     Config::verge().draft().patch_config(patch.clone());
 
     tracing::debug!("resolve config settings");
-    let res = resolve_config_settings(patch).await;
+    let res = {
+        let enable_external_controller = patch.enable_external_controller;
+        let auto_launch = patch.enable_auto_launch;
+        let system_proxy = patch.enable_system_proxy;
+        let pac = patch.proxy_auto_config;
+        let pac_content = patch.pac_file_content;
+        // bypass
+        let proxy_bypass = patch.system_proxy_bypass;
+        let windows_bypass = patch.windows_bypass;
+        let macos_bypass = patch.macos_bypass;
+        let linux_bypass = patch.linux_bypass;
+
+        let language = patch.language;
+        #[cfg(target_os = "macos")]
+        let tray_icon = patch.tray_icon;
+        let common_tray_icon = patch.common_tray_icon;
+        let sysproxy_tray_icon = patch.sysproxy_tray_icon;
+        let tun_tray_icon = patch.tun_tray_icon;
+        let log_level = patch.app_log_level;
+        let enable_tray = patch.enable_tray;
+        let service_mode = patch.enable_service_mode;
+        #[cfg(target_os = "macos")]
+        let show_in_dock = patch.show_in_dock;
+
+        if let Some(enable_external_controller) = enable_external_controller {
+            tracing::info!("enable external controller: {}", enable_external_controller);
+            Config::generate()?;
+            CoreManager::global().run_core().await?;
+        }
+
+        if log_level.is_some() {
+            let log_level = Config::verge().latest().get_log_level();
+            VergeLog::update_log_level(log_level)?;
+        }
+
+        if let Some(service_mode) = service_mode {
+            tracing::debug!("change service mode to {}", service_mode);
+            Config::generate()?;
+            CoreManager::global().run_core().await?;
+        }
+        if auto_launch.is_some() {
+            sysopt::Sysopt::global().update_launch()?;
+        }
+        if system_proxy.is_some()
+            || proxy_bypass.is_some()
+            || windows_bypass.is_some()
+            || macos_bypass.is_some()
+            || linux_bypass.is_some()
+            || pac.is_some()
+            || pac_content.is_some()
+        {
+            tracing::debug!("update system proxy");
+            sysopt::Sysopt::global().update_sysproxy()?;
+        }
+
+        if let Some(true) = patch.enable_proxy_guard {
+            tracing::debug!("enable system proxy guard");
+            sysopt::Sysopt::global().guard_proxy();
+        }
+
+        if let Some(hotkeys) = patch.hotkeys {
+            tracing::debug!("update global hotkeys");
+            hotkey::Hotkey::global().update(hotkeys)?;
+        }
+
+        if let Some(language) = language {
+            tracing::debug!("change app language");
+            rust_i18n::set_locale(&language);
+            handle::Handle::update_systray()?;
+        } else if system_proxy.is_some()
+            || common_tray_icon.is_some()
+            || sysproxy_tray_icon.is_some()
+            || tun_tray_icon.is_some()
+            || service_mode.is_some()
+        {
+            tracing::debug!("update tray cause by some settings changed");
+            handle::Handle::update_systray_part()?;
+        }
+        #[cfg(target_os = "macos")]
+        if tray_icon.is_some() {
+            tracing::debug!("macos tray icon changed, update tray");
+            handle::Handle::update_systray_part()?;
+        }
+
+        if let Some(enable_tray) = enable_tray {
+            tracing::debug!("toggle tray enable: {enable_tray}");
+            handle::Handle::set_tray_visible(enable_tray)?;
+        }
+
+        #[cfg(target_os = "macos")]
+        if let Some(show_in_dock) = show_in_dock {
+            tracing::debug!("toggle show in macos dock, {show_in_dock}");
+            handle::Handle::set_dock_visible(show_in_dock)?;
+        }
+
+        Ok(())
+    };
     match res {
         Ok(()) => {
             Config::verge().apply();
@@ -415,104 +488,6 @@ pub async fn patch_verge(patch: IVerge) -> AppResult<()> {
             Err(err)
         }
     }
-}
-
-async fn resolve_config_settings(patch: IVerge) -> AppResult<()> {
-    let enable_external_controller = patch.enable_external_controller;
-    let auto_launch = patch.enable_auto_launch;
-    let system_proxy = patch.enable_system_proxy;
-    let pac = patch.proxy_auto_config;
-    let pac_content = patch.pac_file_content;
-    // bypass
-    let proxy_bypass = patch.system_proxy_bypass;
-    let windows_bypass = patch.windows_bypass;
-    let macos_bypass = patch.macos_bypass;
-    let linux_bypass = patch.linux_bypass;
-
-    let language = patch.language;
-    #[cfg(target_os = "macos")]
-    let tray_icon = patch.tray_icon;
-    let common_tray_icon = patch.common_tray_icon;
-    let sysproxy_tray_icon = patch.sysproxy_tray_icon;
-    let tun_tray_icon = patch.tun_tray_icon;
-    let log_level = patch.app_log_level;
-    let enable_tray = patch.enable_tray;
-    let service_mode = patch.enable_service_mode;
-    #[cfg(target_os = "macos")]
-    let show_in_dock = patch.show_in_dock;
-
-    if let Some(enable_external_controller) = enable_external_controller {
-        tracing::info!("enable external controller: {}", enable_external_controller);
-        Config::generate()?;
-        CoreManager::global().run_core().await?;
-    }
-
-    if log_level.is_some() {
-        let log_level = Config::verge().latest().get_log_level();
-        VergeLog::update_log_level(log_level)?;
-    }
-
-    if let Some(service_mode) = service_mode {
-        tracing::debug!("change service mode to {}", service_mode);
-        Config::generate()?;
-        CoreManager::global().run_core().await?;
-    }
-    if auto_launch.is_some() {
-        sysopt::Sysopt::global().update_launch()?;
-    }
-    if system_proxy.is_some()
-        || proxy_bypass.is_some()
-        || windows_bypass.is_some()
-        || macos_bypass.is_some()
-        || linux_bypass.is_some()
-        || pac.is_some()
-        || pac_content.is_some()
-    {
-        tracing::debug!("update system proxy");
-        sysopt::Sysopt::global().update_sysproxy()?;
-    }
-
-    if let Some(true) = patch.enable_proxy_guard {
-        tracing::debug!("enable system proxy guard");
-        sysopt::Sysopt::global().guard_proxy();
-    }
-
-    if let Some(hotkeys) = patch.hotkeys {
-        tracing::debug!("update global hotkeys");
-        hotkey::Hotkey::global().update(hotkeys)?;
-    }
-
-    if let Some(language) = language {
-        tracing::debug!("change app language");
-        rust_i18n::set_locale(&language);
-        handle::Handle::update_systray()?;
-    } else if system_proxy.is_some()
-        || common_tray_icon.is_some()
-        || sysproxy_tray_icon.is_some()
-        || tun_tray_icon.is_some()
-        || service_mode.is_some()
-    {
-        tracing::debug!("update tray cause by some settings changed");
-        handle::Handle::update_systray_part()?;
-    }
-    #[cfg(target_os = "macos")]
-    if tray_icon.is_some() {
-        tracing::debug!("macos tray icon changed, update tray");
-        handle::Handle::update_systray_part()?;
-    }
-
-    if let Some(enable_tray) = enable_tray {
-        tracing::debug!("toggle tray enable: {enable_tray}");
-        handle::Handle::set_tray_visible(enable_tray)?;
-    }
-
-    #[cfg(target_os = "macos")]
-    if let Some(show_in_dock) = show_in_dock {
-        tracing::debug!("toggle show in macos dock, {show_in_dock}");
-        handle::Handle::set_dock_visible(show_in_dock)?;
-    }
-
-    Ok(())
 }
 
 /// 更新某个profile

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -43,6 +43,12 @@ pub fn run() -> AppResult<()> {
         return Ok(());
     }
 
+    if utils::unix_helper::is_wayland() {
+        unsafe {
+            std::env::set_var("GDK_BACKEND", "x11");
+        }
+    }
+
     // 初始化目录
     init::init_dirs_and_config()?;
 

--- a/src-tauri/src/utils/resolve.rs
+++ b/src-tauri/src/utils/resolve.rs
@@ -185,11 +185,7 @@ pub fn create_window() {
         .shadow(true)
         .build();
     #[cfg(target_os = "linux")]
-    let window = {
-        use crate::cmds;
-        let visible = _decoration && cmds::common::is_wayland().unwrap_or(false);
-        builder.visible(visible).shadow(true).transparent(true).build()
-    };
+    let window = builder.visible(false).shadow(true).transparent(true).build();
 
     match window {
         Ok(win) => {
@@ -231,7 +227,13 @@ pub fn save_window_size_position(app_handle: &AppHandle) -> AppResult<()> {
         let is_maximized = win.is_maximized()?;
         verge.window_is_maximized = Some(is_maximized);
         if !is_maximized && size.width >= 600.0 && size.height >= 550.0 {
-            verge.window_size_position = Some(vec![size.width, size.height, pos.x, pos.y]);
+            let (width, height) =
+                if utils::unix_helper::is_wayland() && verge.enable_system_title_bar.unwrap_or_default() {
+                    (size.width + 90., size.height + 90.)
+                } else {
+                    (size.width, size.height)
+                };
+            verge.window_size_position = Some(vec![width, height, pos.x, pos.y]);
         }
     }
     verge.save_file()?;

--- a/src-tauri/src/utils/unix_helper.rs
+++ b/src-tauri/src/utils/unix_helper.rs
@@ -12,3 +12,11 @@ pub fn linux_elevator() -> &'static str {
         Err(_) => "sudo",
     }
 }
+
+pub fn is_wayland() -> bool {
+    if cfg!(target_os = "linux") {
+        std::env::var("XDG_SESSION_TYPE").is_ok_and(|session| session.to_lowercase() == "wayland")
+    } else {
+        false
+    }
+}

--- a/src/components/setting/mods/layout-viewer.tsx
+++ b/src/components/setting/mods/layout-viewer.tsx
@@ -2,13 +2,7 @@ import { BaseDialog, DialogRef, SwitchLovely } from "@/components/base";
 import { useNotice } from "@/components/base/notifice";
 import { GuardState } from "@/components/setting/mods/guard-state";
 import { useVerge } from "@/hooks/use-verge";
-import {
-  copyIconFile,
-  getAppDir,
-  isWayland,
-  restartApp,
-} from "@/services/cmds";
-import { sleep } from "@/utils";
+import { copyIconFile, getAppDir } from "@/services/cmds";
 import getSystem from "@/utils/get-system";
 import { InfoRounded } from "@mui/icons-material";
 import {
@@ -45,12 +39,8 @@ export const LayoutViewer = forwardRef<DialogRef>((props, ref) => {
   const [sysproxyIcon, setSysproxyIcon] = useState("");
   const [tunIcon, setTunIcon] = useState("");
   const { enable_system_title_bar, enable_keep_ui_active } = verge || {};
-  const [wayland, setWayland] = useState(false);
 
   useEffect(() => {
-    isWayland().then((wayland) => {
-      setWayland(wayland);
-    });
     initIconPath();
   }, []);
 
@@ -108,18 +98,6 @@ export const LayoutViewer = forwardRef<DialogRef>((props, ref) => {
               primary={
                 <Box sx={{ display: "flex", alignItems: "center" }}>
                   <span>{t("System Title Bar")}</span>
-                  {wayland && (
-                    <Tooltip
-                      title={t("Restart Application to Apply Modifications")}
-                      placement="top">
-                      <IconButton color="inherit" size="small">
-                        <InfoRounded
-                          fontSize="inherit"
-                          style={{ cursor: "pointer", opacity: 0.75 }}
-                        />
-                      </IconButton>
-                    </Tooltip>
-                  )}
                 </Box>
               }
             />
@@ -131,13 +109,7 @@ export const LayoutViewer = forwardRef<DialogRef>((props, ref) => {
               onChange={(e) => onChangeData({ enable_system_title_bar: e })}
               onGuard={async (e) => {
                 await patchVerge({ enable_system_title_bar: e });
-                if (await isWayland()) {
-                  notice("info", t("App Will Be Restarted Soon"));
-                  await sleep(1000);
-                  restartApp();
-                } else {
-                  await appWindow.setDecorations(e);
-                }
+                await appWindow.setDecorations(e);
               }}>
               <SwitchLovely edge="end" />
             </GuardState>


### PR DESCRIPTION
Tauri 在 Linux Wayland 上的支持还不完善，存在 **使用体验** 的问题：
- 无法置顶窗口
- 无法使用原生的窗口装饰器
- 使用 Tauri 在 wayland 下自己绘制的窗口装饰器，若通过 `WebviewWindowBuilder` 创建窗口，其 `visible(..)` 方法设置为 `false` 时，将导致窗口装饰器的按钮（最小化/最大化/退出）都无法进行点击使用

为了提高程序在 wayland 上的使用体验，通过在程序内设置环境变量 `GDK_BACKEND=x11`，使其使用 x11 进行渲染，从而解决上述问题