### PR TITLE
feat(router): optimize page transitions and route preloading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ archbuild/local_build/*
 !archbuild/local_build/clash-verge.install
 !archbuild/local_build/build.sh
 .vfox/
+.env

--- a/src/components/layout/layout-item.tsx
+++ b/src/components/layout/layout-item.tsx
@@ -16,9 +16,20 @@ interface Props {
   children: string;
   icon: React.ReactNode[];
   open: boolean;
+  pending?: boolean;
+  onNavigate?: () => void;
+  onMouseEnter?: () => void;
 }
 export const LayoutItem = (props: Props) => {
-  const { to, children, icon, open } = props;
+  const {
+    to,
+    children,
+    icon,
+    open,
+    pending = false,
+    onNavigate,
+    onMouseEnter,
+  } = props;
   const { verge } = useVerge();
   const matchRoute = useMatchRoute();
   const match = !!matchRoute({ to });
@@ -32,7 +43,7 @@ export const LayoutItem = (props: Props) => {
       placement="right">
       <ListItem sx={{ py: 0.5, padding: "4px 0px", height: "60px" }}>
         <ListItemButton
-          selected={!!match}
+          selected={match || pending}
           sx={(theme) => {
             const color = theme.palette.primary.main;
             return {
@@ -65,13 +76,20 @@ export const LayoutItem = (props: Props) => {
               "&.Mui-selected .MuiListItemIcon-root": { color },
             };
           }}
-          onClick={() => navigate({ to })}>
+          onClick={() => {
+            onNavigate?.();
+            navigate({ to });
+          }}
+          onMouseEnter={onMouseEnter}>
           <div
             className={cn("flex items-center text-center", { "w-full": open })}>
             <div className="flex h-8 w-full items-center justify-center">
               <motion.div layout className={cn({ "relative left-4": open })}>
                 {enableMenuIcon && menu_icon === "monochrome" && (
-                  <Box sx={{ color: match ? "primary.main" : "text.primary" }}>
+                  <Box
+                    sx={{
+                      color: match || pending ? "primary.main" : "text.primary",
+                    }}>
                     {icon[0]}
                   </Box>
                 )}
@@ -81,7 +99,7 @@ export const LayoutItem = (props: Props) => {
                 <div className="w-full">
                   <Typography
                     sx={{
-                      color: match ? "primary.main" : "text.primary",
+                      color: match || pending ? "primary.main" : "text.primary",
                       fontWeight: "bold",
                     }}>
                     {children}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -4,18 +4,52 @@ import { useWindowSize } from "@/hooks/use-window-size";
 import { routes } from "@/routes/__root";
 import { cn } from "@/utils";
 import { List } from "@mui/material";
+import { useRouter, useRouterState } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LayoutItem } from "./layout-item";
 
 interface Props {
   enableSystemTitleBar: boolean;
+  onNavigateStart?: (to: string) => void;
 }
 
 export const Sidebar = (props: Props) => {
-  const { enableSystemTitleBar } = props;
+  const { enableSystemTitleBar, onNavigateStart } = props;
   const { size } = useWindowSize();
   const { t } = useTranslation();
+  const router = useRouter();
+  const pathname = useRouterState({
+    select: (state) => state.location.pathname,
+  });
   const open = size.width >= 650;
+  const [pendingTo, setPendingTo] = useState<string | null>(null);
+
+  useEffect(() => {
+    setPendingTo(null);
+  }, [pathname]);
+
+  useEffect(() => {
+    const preloadRoutes = () => {
+      routes.forEach((route) => {
+        void router.preloadRoute({ to: route.path });
+      });
+    };
+    const windowWithIdleCallback = window as Window & {
+      requestIdleCallback?: (callback: IdleRequestCallback) => number;
+      cancelIdleCallback?: (handle: number) => void;
+    };
+
+    if (windowWithIdleCallback.requestIdleCallback) {
+      const idleId = windowWithIdleCallback.requestIdleCallback(() => {
+        preloadRoutes();
+      });
+      return () => windowWithIdleCallback.cancelIdleCallback?.(idleId);
+    }
+
+    const timeoutId = globalThis.setTimeout(preloadRoutes, 300);
+    return () => globalThis.clearTimeout(timeoutId);
+  }, [router]);
 
   return (
     <div
@@ -42,7 +76,15 @@ export const Sidebar = (props: Props) => {
             open={open}
             key={route.label}
             to={route.path}
-            icon={route.icon}>
+            icon={route.icon}
+            pending={pendingTo === route.path}
+            onMouseEnter={() => {
+              void router.preloadRoute({ to: route.path });
+            }}
+            onNavigate={() => {
+              onNavigateStart?.(route.path);
+              setPendingTo(route.path);
+            }}>
             {t(route.label)}
           </LayoutItem>
         ))}

--- a/src/components/profile/profile-item.tsx
+++ b/src/components/profile/profile-item.tsx
@@ -26,7 +26,7 @@ import {
 } from "@mui/material";
 import { useLockFn } from "ahooks";
 import dayjs from "dayjs";
-import { useEffect, useState } from "react";
+import { memo, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { mutate } from "swr";
 import { useNotice } from "../base/notifies";
@@ -40,20 +40,18 @@ interface Props {
   isDragging?: boolean;
   activating: boolean;
   itemData: IProfileItem;
-  chainLogs: Record<string, LogMessage[]>;
   onSelect: (force: boolean) => void;
   onDelete: () => void;
   onReactivate: () => void;
 }
 
-export const ProfileItem = (props: Props) => {
+export const ProfileItem = memo(function ProfileItem(props: Props) {
   const {
     sx,
     selected,
     isDragging,
     activating,
     itemData,
-    chainLogs,
     onSelect,
     onDelete,
     onReactivate,
@@ -384,7 +382,6 @@ export const ProfileItem = (props: Props) => {
       <ProfileEditorViewer
         open={open}
         profileItem={itemData}
-        chainLogs={chainLogs}
         type="clash"
         onChange={() => {
           if (selected) {
@@ -406,7 +403,7 @@ export const ProfileItem = (props: Props) => {
       />
     </Box>
   );
-};
+});
 
 function parseUrl(url?: string) {
   if (!url) return "";

--- a/src/components/profile/profile-more.tsx
+++ b/src/components/profile/profile-more.tsx
@@ -29,7 +29,7 @@ import {
 import { useLockFn } from "ahooks";
 import { Message } from "console-feed/lib/definitions/Component";
 import dayjs from "dayjs";
-import { useState } from "react";
+import { memo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNotice } from "../base/notifies";
 import { ConfirmViewer } from "./confirm-viewer";
@@ -43,6 +43,7 @@ interface Props {
   selected: boolean;
   isDragging?: boolean;
   itemData: IProfileItem;
+  logs?: LogMessage[];
   chainLogs?: Record<string, LogMessage[]>;
   reactivating: boolean;
   onToggleEnable: (enable: boolean) => void;
@@ -60,12 +61,13 @@ const StyledBadge = styled(Badge)<BadgeProps>(({ theme }) => ({
 }));
 
 // profile enhanced item
-export const ProfileMore = (props: Props) => {
+export const ProfileMore = memo(function ProfileMore(props: Props) {
   const {
     sx,
     selected,
     isDragging,
     itemData,
+    logs = [],
     chainLogs = {},
     reactivating,
     onToggleEnable,
@@ -105,8 +107,6 @@ export const ProfileMore = (props: Props) => {
     setAnchorEl(null);
     return fn();
   };
-
-  const logs = chainLogs[uid] || [];
   const hasError = !!logs.find((e) => e.exception);
 
   const menus = [
@@ -323,7 +323,7 @@ export const ProfileMore = (props: Props) => {
       )}
     </Box>
   );
-};
+});
 
 function parseExpire(expire?: number) {
   if (!expire) return "-";

--- a/src/components/proxy/proxy-group-sidebar.tsx
+++ b/src/components/proxy/proxy-group-sidebar.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@/utils";
 import { Link, Tooltip, Typography } from "@mui/material";
-import { useMemo, useState } from "react";
+import { memo, useMemo, useState } from "react";
 
 interface Props {
   groupNameList: string[];
@@ -13,7 +13,7 @@ type GroupName = {
   shortName: string;
 };
 
-export const ProxyGroupSidebar = (props: Props) => {
+export const ProxyGroupSidebar = memo(function ProxyGroupSidebar(props: Props) {
   const { groupNameList, onGroupNameClick, className } = props;
   const [open, setOpen] = useState(false);
   const groupNameListWithShortName: GroupName[] = useMemo(() => {
@@ -58,4 +58,4 @@ export const ProxyGroupSidebar = (props: Props) => {
       </div>
     </div>
   );
-};
+});

--- a/src/components/proxy/proxy-groups.tsx
+++ b/src/components/proxy/proxy-groups.tsx
@@ -7,7 +7,7 @@ import delayManager from "@/services/delay";
 import { cn } from "@/utils";
 import { Box } from "@mui/material";
 import { useLockFn, useMemoizedFn, useThrottleFn } from "ahooks";
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import {
   closeConnection,
@@ -33,6 +33,41 @@ export const ProxyGroups = (props: Props) => {
   const timeout = verge.default_latency_timeout || 5000;
 
   const virtuosoRef = useRef<VirtuosoHandle>(null);
+  const [groupDelayVersions, setGroupDelayVersions] = useState<
+    Record<string, number>
+  >({});
+  const groupNames = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          renderList
+            .filter((item) => item.type === 0)
+            .map((item) => item.group.name),
+        ),
+      ),
+    [renderList],
+  );
+
+  useEffect(() => {
+    if (!groupNames.length) return;
+
+    const listeners = groupNames.map((groupName) => {
+      const listener = () => {
+        setGroupDelayVersions((prev) => ({
+          ...prev,
+          [groupName]: (prev[groupName] ?? 0) + 1,
+        }));
+      };
+      delayManager.setGroupListener(groupName, listener);
+      return { groupName, listener };
+    });
+
+    return () => {
+      listeners.forEach(({ groupName, listener }) => {
+        delayManager.removeGroupListener(groupName, listener);
+      });
+    };
+  }, [groupNames]);
 
   // 切换分组的节点代理
   const handleChangeProxy = useMemoizedFn(
@@ -200,6 +235,9 @@ export const ProxyGroups = (props: Props) => {
               <ProxyRender
                 key={renderList[index].key}
                 item={renderList[index]}
+                delayVersion={
+                  groupDelayVersions[renderList[index].group.name] ?? 0
+                }
                 onLocation={handleLocation}
                 onCheckAll={handleCheckAll}
                 onChangeProxy={handleChangeProxy}

--- a/src/components/proxy/proxy-head.tsx
+++ b/src/components/proxy/proxy-head.tsx
@@ -19,7 +19,7 @@ import WifiTetheringOffRounded from "@mui/icons-material/WifiTetheringOffRounded
 import WifiTetheringRounded from "@mui/icons-material/WifiTetheringRounded";
 import { Box, IconButton, SxProps, TextField } from "@mui/material";
 import debounce from "lodash-es/debounce";
-import { useEffect, useMemo, useState } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { ProxySortType } from "./use-filter-sort";
 
@@ -30,7 +30,7 @@ interface Props {
   onCheckDelay: () => void;
 }
 
-export const ProxyHead = (props: Props) => {
+export const ProxyHead = memo(function ProxyHead(props: Props) {
   const { sx = {}, groupName } = props;
   const { profiles } = useProfiles();
   const current = profiles?.current || "";
@@ -62,9 +62,19 @@ export const ProxyHead = (props: Props) => {
     delayManager.setUrl(groupName, testUrl || verge?.default_latency_test!);
   }, [groupName, testUrl, verge?.default_latency_test]);
 
-  const filterChange = debounce((text: string) => {
-    headStateActions.setFilterText(text);
-  }, 500);
+  const filterChange = useMemo(
+    () =>
+      debounce((text: string) => {
+        headStateActions.setFilterText(text);
+      }, 500),
+    [headStateActions],
+  );
+
+  useEffect(() => {
+    return () => {
+      filterChange.cancel();
+    };
+  }, [filterChange]);
 
   return (
     <Box
@@ -185,4 +195,4 @@ export const ProxyHead = (props: Props) => {
       )}
     </Box>
   );
-};
+});

--- a/src/components/proxy/proxy-item-mini.tsx
+++ b/src/components/proxy/proxy-item-mini.tsx
@@ -3,8 +3,7 @@ import { useVerge } from "@/hooks/use-verge";
 import delayManager from "@/services/delay";
 import CheckCircleOutlineRounded from "@mui/icons-material/CheckCircleOutlineRounded";
 import { alpha, Box, ListItemButton, styled, Typography } from "@mui/material";
-import { useLockFn, useThrottleFn } from "ahooks";
-import { useEffect, useState } from "react";
+import { memo } from "react";
 
 interface Props {
   groupName: string;
@@ -12,6 +11,7 @@ interface Props {
   fixed: boolean;
   selected: boolean;
   showType?: boolean;
+  delayVersion?: number;
   onClick?: (name: string) => void;
 }
 
@@ -43,36 +43,28 @@ const TypeSpan = styled("span")(
 );
 
 // 多列布局
-export const ProxyItemMini = (props: Props) => {
-  const { groupName, proxy, fixed, selected, showType = true, onClick } = props;
-
-  // -1/<=0 为 不显示
-  // -2 为 loading
-  const [delay, setDelay] = useState(-1);
+export const ProxyItemMini = memo(function ProxyItemMini(props: Props) {
+  const {
+    groupName,
+    proxy,
+    fixed,
+    selected,
+    showType = true,
+    delayVersion,
+    onClick,
+  } = props;
   const { verge } = useVerge();
   const timeout = verge?.default_latency_timeout || 5000;
-
-  useEffect(() => {
-    delayManager.setListener(proxy.name, groupName, setDelay);
-
-    return () => {
-      delayManager.removeListener(proxy.name, groupName);
-    };
-  }, [proxy.name, groupName]);
-
-  useEffect(() => {
-    if (!proxy) return;
-    setDelay(delayManager.getDelayFix(proxy, groupName));
-  }, [proxy]);
+  const delay = delayManager.getDelayFix(proxy, groupName);
 
   const onDelay = async () => {
-    setDelay(-2);
-    setDelay(await delayManager.checkDelay(proxy.name, groupName, timeout));
+    await delayManager.checkDelay(proxy.name, groupName, timeout);
   };
 
   return (
     <ListItemButton
       dense
+      data-delay-version={delayVersion}
       selected={selected}
       onClick={() => onClick?.(proxy.name)}
       sx={[
@@ -229,4 +221,4 @@ export const ProxyItemMini = (props: Props) => {
       )}
     </ListItemButton>
   );
-};
+});

--- a/src/components/proxy/proxy-item.tsx
+++ b/src/components/proxy/proxy-item.tsx
@@ -13,13 +13,14 @@ import {
   Theme,
 } from "@mui/material";
 import { useLockFn } from "ahooks";
-import { useEffect, useState } from "react";
+import { memo } from "react";
 
 interface Props {
   group: IProxyGroupItem;
   proxy: IProxyItem;
   selected: boolean;
   showType?: boolean;
+  delayVersion?: number;
   sx?: SxProps<Theme>;
   onClick?: (name: string) => void;
 }
@@ -50,36 +51,29 @@ const TypeSpan = styled("span")(
   }),
 );
 
-export const ProxyItem = (props: Props) => {
-  const { group, proxy, selected, showType = true, sx, onClick } = props;
-
-  // -1/<=0 为 不显示
-  // -2 为 loading
-  const [delay, setDelay] = useState(-1);
+export const ProxyItem = memo(function ProxyItem(props: Props) {
+  const {
+    group,
+    proxy,
+    selected,
+    showType = true,
+    delayVersion,
+    sx,
+    onClick,
+  } = props;
   const { verge } = useVerge();
   const timeout = verge?.default_latency_timeout || 5000;
-  useEffect(() => {
-    delayManager.setListener(proxy.name, group.name, setDelay);
-
-    return () => {
-      delayManager.removeListener(proxy.name, group.name);
-    };
-  }, [proxy.name, group.name]);
-
-  useEffect(() => {
-    if (!proxy) return;
-    setDelay(delayManager.getDelayFix(proxy, group.name));
-  }, [proxy]);
+  const delay = delayManager.getDelayFix(proxy, group.name);
 
   const onDelay = useLockFn(async () => {
-    setDelay(-2);
-    setDelay(await delayManager.checkDelay(proxy.name, group.name, timeout));
+    await delayManager.checkDelay(proxy.name, group.name, timeout);
   });
 
   return (
     <ListItem sx={sx}>
       <ListItemButton
         dense
+        data-delay-version={delayVersion}
         selected={selected}
         onClick={() => onClick?.(proxy.name)}
         sx={(theme) => {
@@ -196,4 +190,4 @@ export const ProxyItem = (props: Props) => {
       </ListItemButton>
     </ListItem>
   );
-};
+});

--- a/src/components/proxy/proxy-render.tsx
+++ b/src/components/proxy/proxy-render.tsx
@@ -4,7 +4,6 @@ import { downloadIconCache } from "@/services/cmds";
 import {
   createScopedHeadStateActions,
   DEFAULT_STATE,
-  useProxyHeadStateStore,
 } from "@/stores/proxyHeadStateStore";
 import ExpandLessRounded from "@mui/icons-material/ExpandLessRounded";
 import ExpandMoreRounded from "@mui/icons-material/ExpandMoreRounded";
@@ -27,6 +26,7 @@ import type { IRenderItem } from "./use-render-list";
 
 interface RenderProps {
   item: IRenderItem;
+  delayVersion: number;
   onLocation: (group: IProxyGroupItem) => void;
   onCheckAll: (groupName: string) => void;
   onChangeProxy: (group: IProxyGroupItem, proxy: IProxyItem) => void;
@@ -34,6 +34,7 @@ interface RenderProps {
 
 interface ProxyColProps {
   item: IRenderItem;
+  delayVersion: number;
   onChangeProxy: (group: IProxyGroupItem, proxy: IProxyItem) => void;
 }
 
@@ -70,7 +71,7 @@ const StyledTypeBox = styled(ListItemTextChild)(({ theme }) => ({
 }));
 
 const ProxyItemMiniCol = memo(function ProxyItemMiniCol(props: ProxyColProps) {
-  const { item, onChangeProxy } = props;
+  const { item, delayVersion, onChangeProxy } = props;
   const { group, headState, proxyCol } = item;
   return (
     <Box
@@ -89,6 +90,7 @@ const ProxyItemMiniCol = memo(function ProxyItemMiniCol(props: ProxyColProps) {
           fixed={group.fixed === proxy.name}
           selected={group.now === proxy.name}
           showType={headState?.showType}
+          delayVersion={delayVersion}
           onClick={() => onChangeProxy(group, proxy!)}
         />
       ))}
@@ -96,16 +98,11 @@ const ProxyItemMiniCol = memo(function ProxyItemMiniCol(props: ProxyColProps) {
   );
 });
 
-export const ProxyRender = (props: RenderProps) => {
-  const { item, onLocation, onCheckAll, onChangeProxy } = props;
-  const { type, group, proxy } = item;
+export const ProxyRender = memo(function ProxyRender(props: RenderProps) {
+  const { item, delayVersion, onLocation, onCheckAll, onChangeProxy } = props;
+  const { type, group, proxy, headState = DEFAULT_STATE } = item;
   const { profiles } = useProfiles();
   const current = profiles?.current || "";
-  const headState = useProxyHeadStateStore((state) =>
-    current
-      ? (state.headStates[current]?.[group.name] ?? DEFAULT_STATE)
-      : DEFAULT_STATE,
-  );
   const { verge } = useVerge();
   const headStateActions = useMemo(
     () => createScopedHeadStateActions({ current, groupName: group.name }),
@@ -113,16 +110,16 @@ export const ProxyRender = (props: RenderProps) => {
   );
   const enable_group_icon = verge?.enable_group_icon ?? true;
   const [iconCachePath, setIconCachePath] = useState("");
-
-  useEffect(() => {
-    initIconCachePath();
-  }, [group]);
+  const groupIcon = group.icon?.trim() ?? "";
+  const isHttpIcon = groupIcon.startsWith("http");
+  const isDataIcon = groupIcon.startsWith("data");
+  const isInlineSvgIcon = groupIcon.startsWith("<svg");
 
   const initIconCachePath = useMemoizedFn(async () => {
-    if (group.icon && group.icon.trim().startsWith("http")) {
+    if (isHttpIcon) {
       const fileName =
-        group.name.replaceAll(" ", "") + "-" + getFileName(group.icon);
-      const iconPath = await downloadIconCache(group.icon, fileName);
+        group.name.replaceAll(" ", "") + "-" + getFileName(groupIcon);
+      const iconPath = await downloadIconCache(groupIcon, fileName);
       setIconCachePath(convertFileSrc(iconPath));
     }
   });
@@ -130,6 +127,14 @@ export const ProxyRender = (props: RenderProps) => {
   const getFileName = useMemoizedFn((url: string) => {
     return url.substring(url.lastIndexOf("/") + 1);
   });
+
+  useEffect(() => {
+    if (!isHttpIcon) {
+      setIconCachePath("");
+      return;
+    }
+    initIconCachePath();
+  }, [initIconCachePath, isHttpIcon]);
 
   if (type === 0) {
     return (
@@ -147,32 +152,26 @@ export const ProxyRender = (props: RenderProps) => {
           transition: "background-color 0s",
         })}
         onClick={() => headStateActions.setOpen(!headState?.open)}>
-        {enable_group_icon &&
-          group.icon &&
-          group.icon.trim().startsWith("http") && (
-            <img
-              src={iconCachePath === "" ? group.icon : iconCachePath}
-              width="32px"
-              style={{ marginRight: "12px", borderRadius: "6px" }}
-            />
-          )}
-        {enable_group_icon &&
-          group.icon &&
-          group.icon.trim().startsWith("data") && (
-            <img
-              src={group.icon}
-              width="32px"
-              style={{ marginRight: "12px", borderRadius: "6px" }}
-            />
-          )}
-        {enable_group_icon &&
-          group.icon &&
-          group.icon.trim().startsWith("<svg") && (
-            <img
-              src={`data:image/svg+xml;base64,${btoa(group.icon)}`}
-              width="32px"
-            />
-          )}
+        {enable_group_icon && isHttpIcon && (
+          <img
+            src={iconCachePath === "" ? groupIcon : iconCachePath}
+            width="32px"
+            style={{ marginRight: "12px", borderRadius: "6px" }}
+          />
+        )}
+        {enable_group_icon && isDataIcon && (
+          <img
+            src={groupIcon}
+            width="32px"
+            style={{ marginRight: "12px", borderRadius: "6px" }}
+          />
+        )}
+        {enable_group_icon && isInlineSvgIcon && (
+          <img
+            src={`data:image/svg+xml;base64,${btoa(groupIcon)}`}
+            width="32px"
+          />
+        )}
         <ListItemText
           primary={<StyledPrimary>{group.name}</StyledPrimary>}
           secondary={
@@ -220,6 +219,7 @@ export const ProxyRender = (props: RenderProps) => {
         proxy={proxy!}
         selected={group.now === proxy?.name}
         showType={headState?.showType}
+        delayVersion={delayVersion}
         sx={{ py: 0, pl: 2 }}
         onClick={() => onChangeProxy(group, proxy!)}
       />
@@ -244,6 +244,12 @@ export const ProxyRender = (props: RenderProps) => {
   }
 
   if (type === 4) {
-    return <ProxyItemMiniCol item={item} onChangeProxy={onChangeProxy} />;
+    return (
+      <ProxyItemMiniCol
+        item={item}
+        delayVersion={delayVersion}
+        onChangeProxy={onChangeProxy}
+      />
+    );
   }
-};
+});

--- a/src/components/proxy/proxy-render.tsx
+++ b/src/components/proxy/proxy-render.tsx
@@ -115,14 +115,16 @@ export const ProxyRender = memo(function ProxyRender(props: RenderProps) {
   const isDataIcon = groupIcon.startsWith("data");
   const isInlineSvgIcon = groupIcon.startsWith("<svg");
 
-  const initIconCachePath = useMemoizedFn(async () => {
-    if (isHttpIcon) {
-      const fileName =
-        group.name.replaceAll(" ", "") + "-" + getFileName(groupIcon);
-      const iconPath = await downloadIconCache(groupIcon, fileName);
-      setIconCachePath(convertFileSrc(iconPath));
-    }
-  });
+  const initIconCachePath = useMemoizedFn(
+    async (groupName: string, groupIcon: string) => {
+      if (isHttpIcon) {
+        const fileName =
+          groupName.replaceAll(" ", "") + "-" + getFileName(groupIcon);
+        const iconPath = await downloadIconCache(groupIcon, fileName);
+        setIconCachePath(convertFileSrc(iconPath));
+      }
+    },
+  );
 
   const getFileName = useMemoizedFn((url: string) => {
     return url.substring(url.lastIndexOf("/") + 1);
@@ -133,8 +135,8 @@ export const ProxyRender = memo(function ProxyRender(props: RenderProps) {
       setIconCachePath("");
       return;
     }
-    initIconCachePath();
-  }, [initIconCachePath, isHttpIcon]);
+    initIconCachePath(group.name, groupIcon);
+  }, [initIconCachePath, isHttpIcon, group.name, groupIcon]);
 
   if (type === 0) {
     return (

--- a/src/components/setting/setting-clash.tsx
+++ b/src/components/setting/setting-clash.tsx
@@ -34,6 +34,7 @@ import { ControllerViewer } from "./mods/controller-viewer";
 import { GuardState } from "./mods/guard-state";
 import { NetInfoViewer } from "./mods/net-info-viewer";
 import { SettingItem, SettingList } from "./mods/setting-comp";
+import { useLazyDialogRef } from "./use-lazy-dialog-ref";
 import { WebUIViewer } from "./mods/web-ui-viewer";
 
 const OS = getSystem();
@@ -79,13 +80,13 @@ const SettingClash = ({ onError }: Props) => {
     !(isLinuxPortable && permissionsGranted) && serviceStatus !== "active";
   const setLogLevel = useClashLogStore((s) => s.setLogLevel);
 
-  const webRef = useRef<DialogRef>(null);
-  const portRef = useRef<DialogRef>(null);
-  const ctrlRef = useRef<DialogRef>(null);
-  const coreRef = useRef<DialogRef>(null);
-  const tunRef = useRef<DialogRef>(null);
-  const serviceRef = useRef<DialogRef>(null);
-  const netInfoRef = useRef<DialogRef>(null);
+  const webRef = useLazyDialogRef<DialogRef>();
+  const portRef = useLazyDialogRef<DialogRef>();
+  const ctrlRef = useLazyDialogRef<DialogRef>();
+  const coreRef = useLazyDialogRef<DialogRef>();
+  const tunRef = useLazyDialogRef<DialogRef>();
+  const serviceRef = useLazyDialogRef<DialogRef>();
+  const netInfoRef = useLazyDialogRef<DialogRef>();
 
   useEffect(() => {
     if (!verge) return;
@@ -130,16 +131,23 @@ const SettingClash = ({ onError }: Props) => {
 
   return (
     <SettingList title={t("Clash Setting")}>
-      <TunViewer ref={tunRef} />
-      <WebUIViewer ref={webRef} />
-      <ClashPortViewer ref={portRef} />
-      <ControllerViewer ref={ctrlRef} />
-      <ClashCoreViewer
-        ref={coreRef}
-        serviceActive={serviceStatus === "active"}
-      />
-      <ServiceViewer ref={serviceRef} enable={!!enable_service_mode} />
-      <NetInfoViewer ref={netInfoRef} />
+      {tunRef.mounted && <TunViewer ref={tunRef.dialogRef} />}
+      {webRef.mounted && <WebUIViewer ref={webRef.dialogRef} />}
+      {portRef.mounted && <ClashPortViewer ref={portRef.dialogRef} />}
+      {ctrlRef.mounted && <ControllerViewer ref={ctrlRef.dialogRef} />}
+      {coreRef.mounted && (
+        <ClashCoreViewer
+          ref={coreRef.dialogRef}
+          serviceActive={serviceStatus === "active"}
+        />
+      )}
+      {serviceRef.mounted && (
+        <ServiceViewer
+          ref={serviceRef.dialogRef}
+          enable={!!enable_service_mode}
+        />
+      )}
+      {netInfoRef.mounted && <NetInfoViewer ref={netInfoRef.dialogRef} />}
 
       <SettingItem
         disabled={disableTunSetting}
@@ -156,7 +164,7 @@ const SettingClash = ({ onError }: Props) => {
               <IconButton
                 color="inherit"
                 size="small"
-                onClick={() => tunRef.current?.open()}>
+                onClick={() => tunRef.open()}>
                 <Settings fontSize="inherit" style={{ opacity: 0.75 }} />
               </IconButton>
             )}
@@ -179,7 +187,7 @@ const SettingClash = ({ onError }: Props) => {
           <IconButton
             color="inherit"
             size="small"
-            onClick={() => serviceRef.current?.open()}>
+            onClick={() => serviceRef.open()}>
             <PrivacyTipRounded
               color={
                 serviceStatus === "active" || serviceStatus === "installed"
@@ -236,7 +244,7 @@ const SettingClash = ({ onError }: Props) => {
               color="inherit"
               size="small"
               onClick={() => {
-                netInfoRef.current?.open();
+                netInfoRef.open();
               }}>
               <Lan fontSize="inherit" sx={{ opacity: 0.75 }} />
             </IconButton>
@@ -346,7 +354,7 @@ const SettingClash = ({ onError }: Props) => {
           value={clash?.["mixed-port"] ?? 7890}
           sx={{ width: 100, input: { py: "7.5px", cursor: "pointer" } }}
           onClick={(e) => {
-            portRef.current?.open();
+            portRef.open();
             (e.target as any).blur();
           }}
         />
@@ -358,7 +366,7 @@ const SettingClash = ({ onError }: Props) => {
           <IconButton
             color="inherit"
             size="small"
-            onClick={() => ctrlRef.current?.open()}>
+            onClick={() => ctrlRef.open()}>
             <Settings fontSize="inherit" style={{ opacity: 0.75 }} />
           </IconButton>
         }>
@@ -374,7 +382,7 @@ const SettingClash = ({ onError }: Props) => {
 
       <SettingItem
         openMoreSettings
-        onClick={() => webRef.current?.open()}
+        onClick={() => webRef.open()}
         label={t("Web UI")}
       />
 
@@ -384,7 +392,7 @@ const SettingClash = ({ onError }: Props) => {
           <IconButton
             color="inherit"
             size="small"
-            onClick={() => coreRef.current?.open()}>
+            onClick={() => coreRef.open()}>
             <Settings
               fontSize="inherit"
               style={{ cursor: "pointer", opacity: 0.75 }}

--- a/src/components/setting/setting-system.tsx
+++ b/src/components/setting/setting-system.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from "react-i18next";
 import { GuardState } from "./mods/guard-state";
 import { SettingItem, SettingList } from "./mods/setting-comp";
 import { SysproxyViewer } from "./mods/sysproxy-viewer";
+import { useLazyDialogRef } from "./use-lazy-dialog-ref";
 
 interface Props {
   onError?: (err: Error) => void;
@@ -18,7 +19,7 @@ const SettingSystem = ({ onError }: Props) => {
 
   const { verge, mutateVerge, patchVerge } = useVerge();
 
-  const sysproxyRef = useRef<DialogRef>(null);
+  const sysproxyRef = useLazyDialogRef<DialogRef>();
 
   const {
     enable_auto_launch,
@@ -34,7 +35,7 @@ const SettingSystem = ({ onError }: Props) => {
 
   return (
     <SettingList title={t("System Setting")}>
-      <SysproxyViewer ref={sysproxyRef} />
+      {sysproxyRef.mounted && <SysproxyViewer ref={sysproxyRef.dialogRef} />}
 
       <SettingItem
         label={t("System Proxy")}
@@ -51,7 +52,7 @@ const SettingSystem = ({ onError }: Props) => {
             <IconButton
               color="inherit"
               size="small"
-              onClick={() => sysproxyRef.current?.open()}>
+              onClick={() => sysproxyRef.open()}>
               <Settings
                 fontSize="inherit"
                 style={{ cursor: "pointer", opacity: 0.75 }}

--- a/src/components/setting/setting-verge.tsx
+++ b/src/components/setting/setting-verge.tsx
@@ -57,6 +57,7 @@ import { MiscViewer } from "./mods/misc-viewer";
 import { SettingItem, SettingList } from "./mods/setting-comp";
 import { ThemeModeSwitch } from "./mods/theme-mode-switch";
 import { ThemeViewer } from "./mods/theme-viewer";
+import { useLazyDialogRef } from "./use-lazy-dialog-ref";
 import { UpdateViewer } from "./mods/update-viewer";
 
 interface Props {
@@ -82,13 +83,13 @@ const SettingVerge = ({ onError }: Props) => {
     webdav_username,
     webdav_password,
   } = verge;
-  const configRef = useRef<DialogRef>(null);
-  const hotkeyRef = useRef<DialogRef>(null);
-  const miscRef = useRef<DialogRef>(null);
-  const themeRef = useRef<DialogRef>(null);
-  const layoutRef = useRef<DialogRef>(null);
-  const updateRef = useRef<DialogRef>(null);
-  const webDavRef = useRef<WebDavFilesViewerRef>(null);
+  const configRef = useLazyDialogRef<DialogRef>();
+  const hotkeyRef = useLazyDialogRef<DialogRef>();
+  const miscRef = useLazyDialogRef<DialogRef>();
+  const themeRef = useLazyDialogRef<DialogRef>();
+  const layoutRef = useLazyDialogRef<DialogRef>();
+  const updateRef = useLazyDialogRef<DialogRef>();
+  const webDavRef = useLazyDialogRef<WebDavFilesViewerRef>();
 
   const onChangeData = (patch: Partial<IVergeConfig>) => {
     mutateVerge({ ...verge, ...patch }, false);
@@ -100,7 +101,7 @@ const SettingVerge = ({ onError }: Props) => {
       if (!info) {
         notice("success", t("Currently on the Latest Version"));
       } else {
-        updateRef.current?.open();
+        updateRef.open();
       }
     } catch (err: any) {
       notice("error", err.message || err.toString());
@@ -144,8 +145,13 @@ const SettingVerge = ({ onError }: Props) => {
         await updateWebDavInfo(data.url, data.username, data.password);
       } else {
         setLoadingBackupFiles(true);
-        await webDavRef.current?.getAllBackupFiles();
-        webDavRef.current?.open();
+        await new Promise<void>((resolve) => {
+          webDavRef.withDialog(async (ref) => {
+            await ref.getAllBackupFiles();
+            ref.open();
+            resolve();
+          });
+        });
       }
     } catch (e: any) {
       notice("error", t("WebDav Connection Failed", { error: e }), 3000);
@@ -192,13 +198,13 @@ const SettingVerge = ({ onError }: Props) => {
 
   return (
     <SettingList title={t("Verge Setting")}>
-      <ThemeViewer ref={themeRef} />
-      <ConfigViewer ref={configRef} />
-      <HotkeyViewer ref={hotkeyRef} />
-      <MiscViewer ref={miscRef} />
-      <LayoutViewer ref={layoutRef} />
-      <UpdateViewer ref={updateRef} />
-      <WebDavFilesViewer ref={webDavRef} />
+      {themeRef.mounted && <ThemeViewer ref={themeRef.dialogRef} />}
+      {configRef.mounted && <ConfigViewer ref={configRef.dialogRef} />}
+      {hotkeyRef.mounted && <HotkeyViewer ref={hotkeyRef.dialogRef} />}
+      {miscRef.mounted && <MiscViewer ref={miscRef.dialogRef} />}
+      {layoutRef.mounted && <LayoutViewer ref={layoutRef.dialogRef} />}
+      {updateRef.mounted && <UpdateViewer ref={updateRef.dialogRef} />}
+      {webDavRef.mounted && <WebDavFilesViewer ref={webDavRef.dialogRef} />}
 
       <SettingItem label={t("App Log Level")}>
         <GuardState
@@ -356,19 +362,19 @@ const SettingVerge = ({ onError }: Props) => {
 
       <SettingItem
         openMoreSettings
-        onClick={() => themeRef.current?.open()}
+        onClick={() => themeRef.open()}
         label={t("Theme Setting")}
       />
 
       <SettingItem
         openMoreSettings
-        onClick={() => layoutRef.current?.open()}
+        onClick={() => layoutRef.open()}
         label={t("Layout Setting")}
       />
 
       <SettingItem
         openMoreSettings
-        onClick={() => miscRef.current?.open()}
+        onClick={() => miscRef.open()}
         label={t("Miscellaneous")}
       />
 
@@ -548,12 +554,12 @@ const SettingVerge = ({ onError }: Props) => {
 
       <SettingItem
         openMoreSettings
-        onClick={() => hotkeyRef.current?.open()}
+        onClick={() => hotkeyRef.open()}
         label={t("Hotkey Setting")}
       />
 
       <SettingItem
-        onClick={() => configRef.current?.open()}
+        onClick={() => configRef.open()}
         label={t("Runtime Config")}
       />
 

--- a/src/components/setting/use-lazy-dialog-ref.ts
+++ b/src/components/setting/use-lazy-dialog-ref.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export function useLazyDialogRef<T extends object>() {
+  const dialogRef = useRef<T>(null);
+  const [mounted, setMounted] = useState(false);
+  const pendingActionsRef = useRef<Array<(ref: T) => void>>([]);
+
+  useEffect(() => {
+    const ref = dialogRef.current;
+    if (!mounted || !ref || pendingActionsRef.current.length === 0) return;
+
+    const pendingActions = pendingActionsRef.current.splice(0);
+    pendingActions.forEach((action) => action(ref));
+  }, [mounted]);
+
+  const ensureMounted = useCallback(() => {
+    setMounted(true);
+  }, []);
+
+  const withDialog = useCallback((action: (ref: T) => void) => {
+    if (dialogRef.current) {
+      action(dialogRef.current);
+      return;
+    }
+
+    pendingActionsRef.current.push(action);
+    setMounted(true);
+  }, []);
+
+  const open = useCallback(() => {
+    withDialog((ref) => {
+      (ref as { open?: () => void }).open?.();
+    });
+  }, [withDialog]);
+
+  return {
+    dialogRef,
+    mounted,
+    ensureMounted,
+    withDialog,
+    open,
+  };
+}

--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -147,26 +147,20 @@ const Layout = () => {
   }, [language, visible]);
 
   useEffect(() => {
-    if (!pendingPath || pathname !== pendingPath) return;
+    if (!pendingPath) return;
 
-    const timeoutId = globalThis.setTimeout(() => {
+    const stopRouteLoading = () => {
       setShowRouteLoading(false);
       setPendingPath(null);
-    }, 180);
+    };
+
+    const timeoutId = globalThis.setTimeout(
+      stopRouteLoading,
+      pathname === pendingPath ? 180 : 4000,
+    );
 
     return () => globalThis.clearTimeout(timeoutId);
   }, [pathname, pendingPath]);
-
-  useEffect(() => {
-    if (!showRouteLoading || !pendingPath) return;
-
-    const timeoutId = globalThis.setTimeout(() => {
-      setShowRouteLoading(false);
-      setPendingPath(null);
-    }, 4000);
-
-    return () => globalThis.clearTimeout(timeoutId);
-  }, [showRouteLoading, pendingPath]);
 
   return (
     <SWRConfig

--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -13,7 +13,7 @@ import LoadingPage from "@/pages/loading";
 import { cn } from "@/utils";
 import getSystem from "@/utils/get-system";
 import { Paper, ThemeProvider } from "@mui/material";
-import { Outlet } from "@tanstack/react-router";
+import { Outlet, useRouterState } from "@tanstack/react-router";
 import { Event, listen } from "@tauri-apps/api/event";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import dayjs from "dayjs";
@@ -38,6 +38,8 @@ interface NoticePayload {
 const Layout = () => {
   usePortable();
   const [isMaximized, setIsMaximized] = useState(false);
+  const [pendingPath, setPendingPath] = useState<string | null>(null);
+  const [showRouteLoading, setShowRouteLoading] = useState(false);
   const { t } = useTranslation();
   const { notice } = useNotice();
   useSyncThemeSettings();
@@ -45,6 +47,9 @@ const Layout = () => {
   const visible = useVisibility();
   const { verge } = useVerge();
   const { language, enable_system_title_bar, enable_keep_ui_active } = verge;
+  const pathname = useRouterState({
+    select: (state) => state.location.pathname,
+  });
 
   keepUIActive = enable_keep_ui_active || false;
 
@@ -136,6 +141,28 @@ const Layout = () => {
     }
   }, [language, visible]);
 
+  useEffect(() => {
+    if (!pendingPath || pathname !== pendingPath) return;
+
+    const timeoutId = globalThis.setTimeout(() => {
+      setShowRouteLoading(false);
+      setPendingPath(null);
+    }, 180);
+
+    return () => globalThis.clearTimeout(timeoutId);
+  }, [pathname, pendingPath]);
+
+  useEffect(() => {
+    if (!showRouteLoading || !pendingPath) return;
+
+    const timeoutId = globalThis.setTimeout(() => {
+      setShowRouteLoading(false);
+      setPendingPath(null);
+    }, 4000);
+
+    return () => globalThis.clearTimeout(timeoutId);
+  }, [showRouteLoading, pendingPath]);
+
   return (
     <SWRConfig
       value={{
@@ -167,7 +194,14 @@ const Layout = () => {
               e.preventDefault();
             }
           }}>
-          <Sidebar enableSystemTitleBar={!!enable_system_title_bar} />
+          <Sidebar
+            enableSystemTitleBar={!!enable_system_title_bar}
+            onNavigateStart={(to) => {
+              if (to === pathname) return;
+              setPendingPath(to);
+              setShowRouteLoading(true);
+            }}
+          />
 
           <div className="flex h-full w-full flex-col overflow-hidden">
             {!enable_system_title_bar && (
@@ -182,10 +216,15 @@ const Layout = () => {
               </div>
             )}
 
-            <div className="flex-auto overflow-auto py-1 pr-1">
+            <div className="bg-comment relative flex-auto overflow-auto py-1 pr-1 dark:bg-[#1e1f27]">
               <Suspense fallback={<LoadingPage />}>
                 <Outlet />
               </Suspense>
+              {showRouteLoading && (
+                <div className="absolute inset-0 z-20 transition-opacity duration-150">
+                  <LoadingPage />
+                </div>
+              )}
             </div>
             <TailwindIndicator />
           </div>

--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -22,7 +22,7 @@ import "dayjs/locale/zh-cn";
 import relativeTime from "dayjs/plugin/relativeTime";
 import i18next from "i18next";
 import { debounce } from "lodash-es";
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { SWRConfig, mutate } from "swr";
 
@@ -40,6 +40,7 @@ const Layout = () => {
   const [isMaximized, setIsMaximized] = useState(false);
   const [pendingPath, setPendingPath] = useState<string | null>(null);
   const [showRouteLoading, setShowRouteLoading] = useState(false);
+  const visitedPathsRef = useRef(new Set<string>());
   const { t } = useTranslation();
   const { notice } = useNotice();
   useSyncThemeSettings();
@@ -52,6 +53,10 @@ const Layout = () => {
   });
 
   keepUIActive = enable_keep_ui_active || false;
+
+  useEffect(() => {
+    visitedPathsRef.current.add(pathname);
+  }, [pathname]);
 
   const handleClose = (keepUIActive: boolean) => {
     const appWindow = getCurrentWebviewWindow();
@@ -198,6 +203,7 @@ const Layout = () => {
             enableSystemTitleBar={!!enable_system_title_bar}
             onNavigateStart={(to) => {
               if (to === pathname) return;
+              if (visitedPathsRef.current.has(to)) return;
               setPendingPath(to);
               setShowRouteLoading(true);
             }}

--- a/src/pages/loading.tsx
+++ b/src/pages/loading.tsx
@@ -3,7 +3,7 @@ import { ClimbingBoxLoader } from "react-spinners";
 
 export default function LoadingPage() {
   return (
-    <Box className="bg-comment flex h-full w-full flex-col items-center justify-center">
+    <Box className="bg-comment flex h-full min-h-full w-full flex-col items-center justify-center dark:bg-[#1e1f27]">
       <Typography className="text-primary-main" variant="h4">
         Loading...
       </Typography>

--- a/src/pages/profiles.tsx
+++ b/src/pages/profiles.tsx
@@ -101,6 +101,10 @@ const ProfilePage = () => {
       .map((i) => i.uid);
     return { profileItems, globalChains, enabledChainUids };
   }, [profiles]);
+  const activatingUidSet = useMemo(
+    () => new Set(activatingUids),
+    [activatingUids],
+  );
 
   // sortable
   const sensors = useSensors(
@@ -108,6 +112,14 @@ const ProfilePage = () => {
   );
   const [profileList, setProfileList] = useState<IProfileItem[]>([]);
   const [chainList, setChainList] = useState<IProfileItem[]>([]);
+  const profileSortableIds = useMemo(
+    () => profileList.map((item) => item.uid),
+    [profileList],
+  );
+  const chainSortableIds = useMemo(
+    () => chainList.map((item) => item.uid),
+    [chainList],
+  );
   const dropAnimationConfig: DropAnimation = {
     sideEffects: defaultDropAnimationSideEffects({
       styles: { active: { opacity: "0.5" } },
@@ -469,7 +481,7 @@ const ProfilePage = () => {
           onDragEnd={(e) => handleProfileDragEnd(e)}
           onDragCancel={() => setDraggingItem(null)}>
           <Box>
-            <SortableContext items={profileList.map((item) => item.uid)}>
+            <SortableContext items={profileSortableIds}>
               <Box sx={{ display: "flex", flexWrap: "wrap" }}>
                 {profileList.map((item) => (
                   <DraggableItem
@@ -483,14 +495,13 @@ const ProfilePage = () => {
                     }}>
                     <ProfileItem
                       selected={
-                        activatingUids.includes(item.uid) ||
+                        activatingUidSet.has(item.uid) ||
                         (activatingUids.length === 0 &&
                           profiles.current === item.uid)
                       }
                       isDragging={draggingItem?.uid === item.uid}
-                      activating={activatingUids.includes(item.uid)}
+                      activating={activatingUidSet.has(item.uid)}
                       itemData={item}
-                      chainLogs={chainLogs}
                       onSelect={(f) => onSelect(item.uid, f)}
                       onDelete={() => onDelete(item.uid)}
                       // onEdit={() => viewerRef.current?.edit(item)}
@@ -511,13 +522,12 @@ const ProfilePage = () => {
                   boxShadow: "0px 0px 10px 5px rgba(0,0,0,0.2)",
                 }}
                 selected={
-                  activatingUids.includes(draggingItem.uid) ||
+                  activatingUidSet.has(draggingItem.uid) ||
                   (activatingUids.length === 0 &&
                     profiles.current === draggingItem.uid)
                 }
-                activating={activatingUids.includes(draggingItem.uid)}
+                activating={activatingUidSet.has(draggingItem.uid)}
                 itemData={draggingItem}
-                chainLogs={chainLogs}
                 onSelect={(f) => onSelect(draggingItem.uid, f)}
                 onDelete={() => onDelete(draggingItem.uid)}
                 // onEdit={() => viewerRef.current?.edit(draggingProfileItem)}
@@ -562,7 +572,7 @@ const ProfilePage = () => {
               onDragCancel={() => setDraggingItem(null)}>
               <Box sx={{ display: "flex", flexWrap: "wrap" }}>
                 <SortableContext
-                  items={chainList.map((item) => item.uid)}
+                  items={chainSortableIds}
                   strategy={rectSortingStrategy}>
                   {chainList.map((item) => (
                     <DraggableItem
@@ -577,10 +587,11 @@ const ProfilePage = () => {
                       }}>
                       <ProfileMore
                         selected={
-                          activatingUids.includes(item.uid) || !!item.enable
+                          activatingUidSet.has(item.uid) || !!item.enable
                         }
                         isDragging={draggingItem?.uid === item.uid}
                         itemData={item}
+                        logs={chainLogs[item.uid]}
                         chainLogs={chainLogs}
                         reactivating={activatingUids.includes(item.uid)}
                         onToggleEnable={async (enable) => {
@@ -599,7 +610,7 @@ const ProfilePage = () => {
                   {draggingItem ? (
                     <ProfileMore
                       selected={
-                        activatingUids.includes(draggingItem.uid) ||
+                        activatingUidSet.has(draggingItem.uid) ||
                         !!draggingItem.enable
                       }
                       itemData={draggingItem}
@@ -608,8 +619,9 @@ const ProfilePage = () => {
                         borderRadius: "8px",
                         boxShadow: "0px 0px 10px 5px rgba(0,0,0,0.2)",
                       }}
+                      logs={chainLogs[draggingItem.uid]}
                       chainLogs={chainLogs}
-                      reactivating={activatingUids.includes(draggingItem.uid)}
+                      reactivating={activatingUidSet.has(draggingItem.uid)}
                       onToggleEnable={async (enable) => {
                         handleToggleEnable(draggingItem.uid, enable);
                       }}

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -7,15 +7,19 @@ import { openWebUrl } from "@/services/cmds";
 import GitHub from "@mui/icons-material/GitHub";
 import { Box, Grid, IconButton } from "@mui/material";
 import { useLockFn } from "ahooks";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 const SettingPage = () => {
   const { t } = useTranslation();
   const { notice } = useNotice();
 
-  const onError = (err: any) => {
-    notice("error", err.message || err.toString());
-  };
+  const onError = useMemo(
+    () => (err: any) => {
+      notice("error", err.message || err.toString());
+    },
+    [notice],
+  );
 
   const openGithubRepo = useLockFn(() => {
     return openWebUrl("https://github.com/oomeow/clash-verge-self");

--- a/src/routes/connections.tsx
+++ b/src/routes/connections.tsx
@@ -1,6 +1,12 @@
-import ConnectionsPage from "@/pages/connections";
 import { createFileRoute } from "@tanstack/react-router";
+import { lazy } from "react";
+
+const ConnectionsPage = lazy(() => import("@/pages/connections"));
+
+function ConnectionsRouteComponent() {
+  return <ConnectionsPage />;
+}
 
 export const Route = createFileRoute("/connections")({
-  component: () => <ConnectionsPage />,
+  component: ConnectionsRouteComponent,
 });

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,6 +1,12 @@
-import ProxyPage from "@/pages/proxies";
 import { createFileRoute } from "@tanstack/react-router";
+import { lazy } from "react";
+
+const ProxyPage = lazy(() => import("@/pages/proxies"));
+
+function IndexRouteComponent() {
+  return <ProxyPage />;
+}
 
 export const Route = createFileRoute("/")({
-  component: () => <ProxyPage />,
+  component: IndexRouteComponent,
 });

--- a/src/routes/logs.tsx
+++ b/src/routes/logs.tsx
@@ -1,6 +1,12 @@
-import LogPage from "@/pages/logs";
 import { createFileRoute } from "@tanstack/react-router";
+import { lazy } from "react";
+
+const LogPage = lazy(() => import("@/pages/logs"));
+
+function LogsRouteComponent() {
+  return <LogPage />;
+}
 
 export const Route = createFileRoute("/logs")({
-  component: () => <LogPage />,
+  component: LogsRouteComponent,
 });

--- a/src/routes/profiles.tsx
+++ b/src/routes/profiles.tsx
@@ -1,6 +1,12 @@
-import ProfilePage from "@/pages/profiles";
 import { createFileRoute } from "@tanstack/react-router";
+import { lazy } from "react";
+
+const ProfilePage = lazy(() => import("@/pages/profiles"));
+
+function ProfilesRouteComponent() {
+  return <ProfilePage />;
+}
 
 export const Route = createFileRoute("/profiles")({
-  component: () => <ProfilePage />,
+  component: ProfilesRouteComponent,
 });

--- a/src/routes/proxies.tsx
+++ b/src/routes/proxies.tsx
@@ -1,6 +1,12 @@
-import ProxyPage from "@/pages/proxies";
 import { createFileRoute } from "@tanstack/react-router";
+import { lazy } from "react";
+
+const ProxyPage = lazy(() => import("@/pages/proxies"));
+
+function ProxiesRouteComponent() {
+  return <ProxyPage />;
+}
 
 export const Route = createFileRoute("/proxies")({
-  component: () => <ProxyPage />,
+  component: ProxiesRouteComponent,
 });

--- a/src/routes/rules.tsx
+++ b/src/routes/rules.tsx
@@ -1,6 +1,12 @@
-import RulesPage from "@/pages/rules";
 import { createFileRoute } from "@tanstack/react-router";
+import { lazy } from "react";
+
+const RulesPage = lazy(() => import("@/pages/rules"));
+
+function RulesRouteComponent() {
+  return <RulesPage />;
+}
 
 export const Route = createFileRoute("/rules")({
-  component: () => <RulesPage />,
+  component: RulesRouteComponent,
 });

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -1,6 +1,12 @@
-import SettingPage from "@/pages/settings";
 import { createFileRoute } from "@tanstack/react-router";
+import { lazy } from "react";
+
+const SettingPage = lazy(() => import("@/pages/settings"));
+
+function SettingsRouteComponent() {
+  return <SettingPage />;
+}
 
 export const Route = createFileRoute("/settings")({
-  component: () => <SettingPage />,
+  component: SettingsRouteComponent,
 });

--- a/src/routes/test.tsx
+++ b/src/routes/test.tsx
@@ -1,6 +1,12 @@
-import TestPage from "@/pages/test";
 import { createFileRoute } from "@tanstack/react-router";
+import { lazy } from "react";
+
+const TestPage = lazy(() => import("@/pages/test"));
+
+function TestRouteComponent() {
+  return <TestPage />;
+}
 
 export const Route = createFileRoute("/test")({
-  component: () => <TestPage />,
+  component: TestRouteComponent,
 });

--- a/src/services/delay.ts
+++ b/src/services/delay.ts
@@ -10,7 +10,7 @@ class DelayManager {
   private listenerMap = new Map<string, (time: number) => void>();
 
   // 每个分组的监听
-  private groupListenerMap = new Map<string, () => void>();
+  private groupListenerMap = new Map<string, Set<() => void>>();
 
   setUrl(group: string, url: string) {
     this.urlMap.set(group, url);
@@ -31,18 +31,30 @@ class DelayManager {
   }
 
   setGroupListener(group: string, listener: () => void) {
-    this.groupListenerMap.set(group, listener);
+    const listeners = this.groupListenerMap.get(group) ?? new Set<() => void>();
+    listeners.add(listener);
+    this.groupListenerMap.set(group, listeners);
   }
 
-  removeGroupListener(group: string) {
-    this.groupListenerMap.delete(group);
+  removeGroupListener(group: string, listener?: () => void) {
+    if (!listener) {
+      this.groupListenerMap.delete(group);
+      return;
+    }
+
+    const listeners = this.groupListenerMap.get(group);
+    if (!listeners) return;
+    listeners.delete(listener);
+    if (listeners.size === 0) {
+      this.groupListenerMap.delete(group);
+    }
   }
 
   setDelay(name: string, group: string, delay: number) {
     const key = hashKey(name, group);
     this.cache.set(key, [Date.now(), delay]);
     this.listenerMap.get(key)?.(delay);
-    this.groupListenerMap.get(group)?.();
+    this.groupListenerMap.get(group)?.forEach((listener) => listener());
   }
 
   getDelay(name: string, group: string) {
@@ -70,6 +82,7 @@ class DelayManager {
 
   async checkDelay(name: string, group: string, timeout: number) {
     let delay = -1;
+    this.setDelay(name, group, -2);
 
     try {
       const url = this.getUrl(group);


### PR DESCRIPTION
## 变更概述
- 为路由切换增加加载态与预加载支持，减少页面切换时的等待感
- 引入已访问路径跟踪，优化侧边栏导航与页面切换行为
- 抽离并延迟初始化部分对话框引用，降低设置页与相关页面的首次渲染开销
- 调整代理、配置、设置等页面组件以适配新的切换与懒加载流程
- 补充 `.gitignore`，忽略 `.vfox` 与 `.env`

## 主要改动
- 在 `src/pages/_layout.tsx`、各路由文件和 `src/pages/loading.tsx` 中接入加载页与预加载逻辑
- 在 `src/components/layout` 下增强导航项与侧边栏状态管理
- 在 `src/components/setting/use-lazy-dialog-ref.ts` 中封装延迟对话框引用复用逻辑
- 调整 `profiles`、`settings`、`proxy` 相关组件，减少不必要的同步渲染
- 更新 `src/services/delay.ts` 以配合新的切页节奏控制

## 验证情况
- 未额外执行自动化测试
