### PR TITLE
fix(mihomo): unify socket path error handling and refactor client initialization

### DIFF
--- a/crates/tauri-plugin-mihomo/src/error.rs
+++ b/crates/tauri-plugin-mihomo/src/error.rs
@@ -6,6 +6,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("Missing {0} parameter")]
+    MissingPathParameter(String),
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
     #[error(transparent)]

--- a/crates/tauri-plugin-mihomo/src/lib.rs
+++ b/crates/tauri-plugin-mihomo/src/lib.rs
@@ -151,6 +151,7 @@ impl Builder {
                 // commands::ws_send,
             ])
             .setup(move |app, _api| {
+                let client = Mihomo::build_client(&protocol, socket_path.as_deref())?;
                 let mihomo = Mihomo {
                     protocol,
                     external_host,
@@ -159,6 +160,7 @@ impl Builder {
                     socket_path,
                     request_timeout,
                     connection_manager: Default::default(),
+                    client,
                 };
                 mihomo.start_ws_connections_watcher();
                 app.manage(RwLock::new(mihomo));

--- a/crates/tauri-plugin-mihomo/src/mihomo.rs
+++ b/crates/tauri-plugin-mihomo/src/mihomo.rs
@@ -37,8 +37,10 @@ pub struct Mihomo {
 }
 
 impl Mihomo {
-    pub fn update_protocol(&mut self, protocol: Protocol) {
+    pub fn update_protocol(&mut self, protocol: Protocol) -> Result<()> {
         self.protocol = protocol;
+        self.client = Self::build_client(&self.protocol, self.socket_path.as_deref())?;
+        Ok(())
     }
 
     pub fn update_external_host(&mut self, host: Option<String>) {
@@ -126,18 +128,19 @@ impl Mihomo {
     fn build_request(&self, method: Method, suffix_url: &str) -> Result<RequestBuilder> {
         let url = self.generate_req_url(suffix_url)?;
         let headers = self.generate_req_headers()?;
-        match method {
-            Method::POST => Ok(self.client.post(url).headers(headers)),
-            Method::GET => Ok(self.client.get(url).headers(headers)),
-            Method::PUT => Ok(self.client.put(url).headers(headers)),
-            Method::PATCH => Ok(self.client.patch(url).headers(headers)),
-            Method::DELETE => Ok(self.client.delete(url).headers(headers)),
+        let request = match method {
+            Method::POST => self.client.post(url),
+            Method::GET => self.client.get(url),
+            Method::PUT => self.client.put(url),
+            Method::PATCH => self.client.patch(url),
+            Method::DELETE => self.client.delete(url),
             _ => {
                 let method_str = method.as_str().to_string();
                 log::error!("method not supported: {method_str}");
-                Err(Error::MethodNotSupported(method_str))
+                return Err(Error::MethodNotSupported(method_str));
             }
-        }
+        };
+        Ok(request.headers(headers).timeout(self.request_timeout))
     }
 
     fn get_websocket_url(&self, suffix_url: &str) -> Result<String> {

--- a/crates/tauri-plugin-mihomo/src/mihomo.rs
+++ b/crates/tauri-plugin-mihomo/src/mihomo.rs
@@ -33,6 +33,7 @@ pub struct Mihomo {
     pub socket_path: Option<String>,
     pub request_timeout: Duration,
     pub connection_manager: Arc<ConnectionManager>,
+    pub client: reqwest::Client,
 }
 
 impl Mihomo {
@@ -52,8 +53,32 @@ impl Mihomo {
         self.secret = secret;
     }
 
-    pub fn update_socket_path<S: Into<String>>(&mut self, socket_path: S) {
+    pub fn update_socket_path<S: Into<String>>(&mut self, socket_path: S) -> Result<()> {
         self.socket_path = Some(socket_path.into());
+        self.client = Self::build_client(&self.protocol, self.socket_path.as_deref())?;
+        Ok(())
+    }
+
+    pub fn build_client(protocol: &Protocol, socket_path: Option<&str>) -> Result<reqwest::Client> {
+        let mut builder = reqwest::ClientBuilder::new();
+        match protocol {
+            Protocol::Http => Ok(builder.build()?),
+            Protocol::LocalSocket => {
+                let Some(socket_path) = socket_path else {
+                    log::error!("missing socket path parameter");
+                    return Err(Error::MissingPathParameter("socket_path".into()));
+                };
+                #[cfg(windows)]
+                {
+                    builder = builder.windows_named_pipe(socket_path);
+                }
+                #[cfg(unix)]
+                {
+                    builder = builder.unix_socket(socket_path);
+                }
+                Ok(builder.build()?)
+            }
+        }
     }
 
     pub fn start_ws_connections_watcher(&self) {
@@ -69,7 +94,7 @@ impl Mihomo {
         });
     }
 
-    fn get_req_url(&self, suffix_url: &str) -> Result<String> {
+    fn generate_req_url(&self, suffix_url: &str) -> Result<String> {
         let suffix_url = suffix_url.trim_start_matches("/");
         match self.protocol {
             Protocol::Http => {
@@ -78,17 +103,14 @@ impl Mihomo {
                     Ok(format!("http://{host}:{port}/{suffix_url}"))
                 } else {
                     log::error!("missing external host parameter");
-                    Err(Error::Io(std::io::Error::new(
-                        std::io::ErrorKind::InvalidInput,
-                        "missing external host".to_string(),
-                    )))
+                    Err(Error::MissingPathParameter("external_host".into()))
                 }
             }
             Protocol::LocalSocket => Ok(format!("http://localhost/{suffix_url}")),
         }
     }
 
-    fn get_req_headers(&self) -> Result<HeaderMap<HeaderValue>> {
+    fn generate_req_headers(&self) -> Result<HeaderMap<HeaderValue>> {
         let mut headers = HeaderMap::new();
         headers.insert(HOST, HeaderValue::from_str("localhost")?);
         headers.insert(CONTENT_TYPE, HeaderValue::from_str("application/json")?);
@@ -102,36 +124,14 @@ impl Mihomo {
     }
 
     fn build_request(&self, method: Method, suffix_url: &str) -> Result<RequestBuilder> {
-        let url = self.get_req_url(suffix_url)?;
-        let headers = self.get_req_headers()?;
-        let client = {
-            let mut builder = reqwest::ClientBuilder::new().timeout(self.request_timeout);
-            if matches!(self.protocol, Protocol::LocalSocket) {
-                let Some(socket_path) = self.socket_path.as_deref() else {
-                    log::error!("missing socket path parameter");
-                    return Err(Error::Io(std::io::Error::new(
-                        std::io::ErrorKind::InvalidInput,
-                        "missing socket path".to_string(),
-                    )));
-                };
-                #[cfg(windows)]
-                {
-                    builder = builder.windows_named_pipe(socket_path);
-                }
-                #[cfg(unix)]
-                {
-                    builder = builder.unix_socket(socket_path);
-                }
-            }
-            builder.build()?
-        };
-
+        let url = self.generate_req_url(suffix_url)?;
+        let headers = self.generate_req_headers()?;
         match method {
-            Method::POST => Ok(client.post(url).headers(headers)),
-            Method::GET => Ok(client.get(url).headers(headers)),
-            Method::PUT => Ok(client.put(url).headers(headers)),
-            Method::PATCH => Ok(client.patch(url).headers(headers)),
-            Method::DELETE => Ok(client.delete(url).headers(headers)),
+            Method::POST => Ok(self.client.post(url).headers(headers)),
+            Method::GET => Ok(self.client.get(url).headers(headers)),
+            Method::PUT => Ok(self.client.put(url).headers(headers)),
+            Method::PATCH => Ok(self.client.patch(url).headers(headers)),
+            Method::DELETE => Ok(self.client.delete(url).headers(headers)),
             _ => {
                 let method_str = method.as_str().to_string();
                 log::error!("method not supported: {method_str}");
@@ -150,10 +150,7 @@ impl Mihomo {
                     Ok(format!("ws://{host}:{port}/{suffix_url}?token={secret}"))
                 } else {
                     log::error!("missing external host parameter");
-                    Err(Error::Io(std::io::Error::new(
-                        std::io::ErrorKind::InvalidInput,
-                        "missing external host".to_string(),
-                    )))
+                    Err(Error::MissingPathParameter("external_host".into()))
                 }
             }
             Protocol::LocalSocket => Ok(format!("ws://localhost/{suffix_url}")),
@@ -265,10 +262,7 @@ impl Mihomo {
                     Ok(id)
                 } else {
                     log::error!("missing socket path parameter");
-                    Err(Error::Io(std::io::Error::new(
-                        std::io::ErrorKind::InvalidInput,
-                        "missing socket path".to_string(),
-                    )))
+                    Err(Error::MissingPathParameter("socket_path".into()))
                 }
             }
         }

--- a/crates/tauri-plugin-mihomo/src/wrap_stream.rs
+++ b/crates/tauri-plugin-mihomo/src/wrap_stream.rs
@@ -22,52 +22,6 @@ pub enum WrapStream {
     NamedPipe(#[pin] NamedPipeClient),
 }
 
-impl WrapStream {
-    pub fn is_available(&self) -> Result<bool> {
-        match self {
-            #[cfg(unix)]
-            WrapStream::Unix(s) => {
-                use std::io::ErrorKind;
-
-                let mut buf = [0u8; 1];
-                match s.try_read(&mut buf) {
-                    Ok(n) => Ok(n != 0),
-                    Err(e) if e.kind() == ErrorKind::WouldBlock => Ok(true),
-                    Err(e) => Err(Error::Io(e)),
-                }
-            }
-            #[cfg(windows)]
-            WrapStream::NamedPipe(s) => {
-                use std::io::ErrorKind;
-
-                let mut buf = [0u8; 1];
-                match s.try_read(&mut buf) {
-                    Ok(n) => Ok(n != 0),
-                    Err(e) if e.kind() == ErrorKind::WouldBlock => Ok(true),
-                    Err(e) => Err(Error::Io(e)),
-                }
-            }
-        }
-    }
-
-    pub async fn readable(&self) -> std::io::Result<()> {
-        match self {
-            #[cfg(unix)]
-            WrapStream::Unix(s) => s.readable().await,
-            #[cfg(windows)]
-            WrapStream::NamedPipe(s) => s.readable().await,
-        }
-    }
-    pub async fn writable(&self) -> std::io::Result<()> {
-        match self {
-            #[cfg(unix)]
-            WrapStream::Unix(s) => s.writable().await,
-            #[cfg(windows)]
-            WrapStream::NamedPipe(s) => s.writable().await,
-        }
-    }
-}
-
 impl AsyncRead for WrapStream {
     fn poll_read(
         self: Pin<&mut Self>,

--- a/crates/tauri-plugin-mihomo/tests/common/mod.rs
+++ b/crates/tauri-plugin-mihomo/tests/common/mod.rs
@@ -12,8 +12,6 @@ pub fn mihomo() -> Mihomo {
     let use_local_socket = std::env::var("MIHOMO_SOCKET").unwrap_or(String::from("0")) == "1";
     let request_timeout = Duration::from_secs(5);
     let socket_path = if use_local_socket {
-        None
-    } else {
         if cfg!(unix) {
             Some("/tmp/self-mihomo.sock".to_string())
             // Some("/tmp/clash-rs.sock".to_string())
@@ -21,6 +19,8 @@ pub fn mihomo() -> Mihomo {
             Some(r"\\.\pipe\self-mihomo".to_string())
             // Some(r"\\.\pipe\clash-rs".to_string())
         }
+    } else {
+        None
     };
     let protocol = if use_local_socket {
         Protocol::LocalSocket

--- a/crates/tauri-plugin-mihomo/tests/common/mod.rs
+++ b/crates/tauri-plugin-mihomo/tests/common/mod.rs
@@ -9,25 +9,37 @@ pub const TIMEOUT: u32 = 3000;
 
 pub fn mihomo() -> Mihomo {
     dotenvy::dotenv().unwrap();
-    let mihomo_socket = std::env::var("MIHOMO_SOCKET").unwrap_or(String::from("0"));
-    if mihomo_socket == "1" {
+    let use_local_socket = std::env::var("MIHOMO_SOCKET").unwrap_or(String::from("0")) == "1";
+    let request_timeout = Duration::from_secs(5);
+    let socket_path = if use_local_socket {
+        None
+    } else {
+        if cfg!(unix) {
+            Some("/tmp/self-mihomo.sock".to_string())
+            // Some("/tmp/clash-rs.sock".to_string())
+        } else {
+            Some(r"\\.\pipe\self-mihomo".to_string())
+            // Some(r"\\.\pipe\clash-rs".to_string())
+        }
+    };
+    let protocol = if use_local_socket {
+        Protocol::LocalSocket
+    } else {
+        Protocol::Http
+    };
+    let client = Mihomo::build_client(&protocol, socket_path.as_deref()).unwrap();
+    if use_local_socket {
         println!("connect to mihomo by local socket");
         // use local socket
-        let socket_path = if cfg!(unix) {
-            "/tmp/self-mihomo.sock".to_string()
-            // "/tmp/clash-rs.sock".to_string()
-        } else {
-            r"\\.\pipe\self-mihomo".to_string()
-            // r"\\.\pipe\clash-rs".to_string()
-        };
         Mihomo {
             protocol: Protocol::LocalSocket,
             external_host: None,
             external_port: None,
             secret: None,
-            socket_path: Some(socket_path),
-            request_timeout: Duration::from_secs(5),
+            socket_path,
+            request_timeout,
             connection_manager: Arc::new(Default::default()),
+            client,
         }
     } else {
         println!("connect to mihomo by http");
@@ -37,9 +49,10 @@ pub fn mihomo() -> Mihomo {
             external_host: Some("127.0.0.1".into()),
             external_port: Some(9090),
             secret: Some("yPMJk9i7UaR1hv3-2BkPy".into()),
-            socket_path: None,
-            request_timeout: Duration::from_secs(5),
+            socket_path,
+            request_timeout,
             connection_manager: Arc::new(Default::default()),
+            client,
         }
     }
 }


### PR DESCRIPTION
## 变更概述
- 统一 mihomo socket 路径相关错误处理，减少分散的异常分支
- 重构客户端初始化流程，简化内部实现并提升可维护性
- 调整测试公共逻辑，使其与新的初始化和错误处理方式保持一致

## 主要改动
- 更新 `crates/tauri-plugin-mihomo/src/mihomo.rs` 中的客户端初始化与 socket 处理逻辑
- 补充 `error.rs`、`lib.rs` 中的错误与导出定义
- 移除 `wrap_stream.rs` 中不再需要的实现
- 调整 `crates/tauri-plugin-mihomo/tests/common/mod.rs` 以适配改动后的行为

## 验证情况
- 未额外执行自动化测试
