### PR TITLE
refactor: improve websocket connection handling and stream abstraction

### DIFF
--- a/crates/tauri-plugin-mihomo/prek.toml
+++ b/crates/tauri-plugin-mihomo/prek.toml
@@ -18,7 +18,7 @@ hooks = [
     id = "cargo-fmt",
     name = "cargo fmt",
     description = "Format files with rustfmt.",
-    entry = "cargo +nightly fmt  -- --check",
+    entry = "cargo +nightly fmt -- --check",
     language = "system",
     types = ["rust"]
   },

--- a/crates/tauri-plugin-mihomo/src/lib.rs
+++ b/crates/tauri-plugin-mihomo/src/lib.rs
@@ -11,7 +11,7 @@ mod commands;
 mod error;
 mod mihomo;
 pub mod models;
-mod wrap_stream;
+mod stream;
 
 pub use error::{Error, Result};
 

--- a/crates/tauri-plugin-mihomo/src/mihomo.rs
+++ b/crates/tauri-plugin-mihomo/src/mihomo.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
-use futures_util::StreamExt;
 use http::{
     HeaderMap, HeaderValue, Request,
     header::{AUTHORIZATION, CONNECTION, CONTENT_TYPE, HOST, SEC_WEBSOCKET_KEY, SEC_WEBSOCKET_VERSION, UPGRADE},
@@ -20,7 +19,7 @@ use crate::{
     models::{
         BaseConfig, CloseFrame, ConnectionManager, Connections, CoreUpdaterChannel, ErrorResponse, Groups, LogLevel,
         MihomoVersion, Protocol, Proxies, Proxy, ProxyDelay, ProxyProvider, ProxyProviders, RuleProviders, Rules,
-        WebSocketConnectionId, WebSocketMessage, WebSocketWriter,
+        WebSocketConnectionId, WebSocketMessage, WsReadeKind, WsStream,
     },
     ret_failed_resp,
 };
@@ -168,24 +167,52 @@ impl Mihomo {
         let id = rand::random();
         log::info!("connecting to websocket: {url}, id: {id}");
         let manager = self.connection_manager.clone();
-        let handle_message = |message| {
+
+        let handle_message = |message: Result<Message>| -> Result<serde_json::Value> {
             // log::trace!("handle message {message:?}");
-            match message {
-                Ok(Message::Text(t)) => serde_json::to_value(WebSocketMessage::Text(t.to_string())).unwrap(),
-                Ok(Message::Binary(t)) => serde_json::to_value(WebSocketMessage::Binary(t.to_vec())).unwrap(),
-                Ok(Message::Ping(t)) => serde_json::to_value(WebSocketMessage::Ping(t.to_vec())).unwrap(),
-                Ok(Message::Pong(t)) => serde_json::to_value(WebSocketMessage::Pong(t.to_vec())).unwrap(),
+            let msg = match message {
+                Ok(Message::Text(t)) => serde_json::to_value(WebSocketMessage::Text(t.to_string()))?,
+                Ok(Message::Binary(t)) => serde_json::to_value(WebSocketMessage::Binary(t.to_vec()))?,
+                Ok(Message::Ping(t)) => serde_json::to_value(WebSocketMessage::Ping(t.to_vec()))?,
+                Ok(Message::Pong(t)) => serde_json::to_value(WebSocketMessage::Pong(t.to_vec()))?,
                 Ok(Message::Close(t)) => serde_json::to_value(WebSocketMessage::Close(t.map(|v| CloseFrame {
                     code: v.code.into(),
                     reason: v.reason.to_string(),
-                })))
-                .unwrap(),
-                Ok(Message::Frame(_)) => serde_json::Value::Null, // This value can't be received.
+                })))?,
+                Ok(Message::Frame(_)) => serde_json::Value::Null, // This value can't be received.;
                 Err(e) => {
                     log::error!("websocket error: {e}");
-                    serde_json::to_value(WebSocketMessage::Text(Error::from(e).to_string())).unwrap()
+                    serde_json::to_value(WebSocketMessage::Text(e.to_string()))?
                 }
-            }
+            };
+            Ok(msg)
+        };
+
+        let spawn_read = move |mut reader: WsReadeKind, on_message: F, manager: Arc<ConnectionManager>| {
+            tokio::spawn(async move {
+                let manager_ = manager.clone();
+                loop {
+                    let ids: Vec<u32> = manager_.0.read().await.keys().cloned().collect();
+                    if !ids.contains(&id) {
+                        log::debug!("connection [{id}] is removed from manager");
+                        break;
+                    }
+                    while let Some(message) = reader.next().await {
+                        let ids: Vec<u32> = manager_.0.read().await.keys().cloned().collect();
+                        if !ids.contains(&id) {
+                            log::debug!("connection [{id}] is removed from manager");
+                            break;
+                        }
+                        if let Ok(Message::Close(_)) = message {
+                            log::debug!("connection [{id}] is closed");
+                            manager_.0.write().await.remove(&id);
+                        }
+                        if let Ok(response) = handle_message(message) {
+                            on_message(response);
+                        }
+                    }
+                }
+            });
         };
 
         match self.protocol {
@@ -193,33 +220,11 @@ impl Mihomo {
                 log::debug!("starting connect to websocket by using http");
                 let request = url.into_client_request()?;
                 let (ws_stream, _) = connect_async(request).await?;
-                let (writer, mut reader) = ws_stream.split();
+                let ws_stream = WsStream::from(ws_stream);
+                let (writer, reader) = ws_stream.split();
 
-                manager
-                    .0
-                    .write()
-                    .await
-                    .insert(id, WebSocketWriter::TcpStreamWriter(writer));
-
-                tokio::spawn(async move {
-                    let manager_ = manager.clone();
-                    loop {
-                        let ids: Vec<u32> = manager_.0.read().await.keys().cloned().collect();
-                        if !ids.contains(&id) {
-                            log::debug!("connection [{id}] is removed from manager");
-                            break;
-                        }
-                        if let Some(message) = reader.next().await {
-                            if let Ok(Message::Close(_)) = message {
-                                log::debug!("connection [{id}] is closed");
-                                manager_.0.write().await.remove(&id);
-                            }
-                            let response = handle_message(message);
-                            on_message(response);
-                        }
-                    }
-                });
-
+                manager.0.write().await.insert(id, writer);
+                spawn_read(reader, on_message, manager.clone());
                 Ok(id)
             }
             Protocol::LocalSocket => {
@@ -236,32 +241,11 @@ impl Mihomo {
                         .header(SEC_WEBSOCKET_VERSION, "13")
                         .body(())?;
                     let (ws_stream, _) = client_async(request, stream).await?;
-                    let (writer, mut reader) = ws_stream.split();
+                    let ws_stream = WsStream::from(ws_stream);
+                    let (writer, reader) = ws_stream.split();
 
-                    manager
-                        .0
-                        .write()
-                        .await
-                        .insert(id, WebSocketWriter::SocketStreamWriter(writer));
-
-                    tokio::spawn(async move {
-                        let manager_ = manager.clone();
-                        loop {
-                            let ids: Vec<u32> = manager_.0.read().await.keys().cloned().collect();
-                            if !ids.contains(&id) {
-                                log::debug!("connection [{id}] is removed from manager");
-                                break;
-                            }
-                            if let Some(message) = reader.next().await {
-                                if let Ok(Message::Close(_)) = message {
-                                    log::debug!("connection [{id}] closed");
-                                    manager_.0.write().await.remove(&id);
-                                }
-                                let response = handle_message(message);
-                                on_message(response);
-                            }
-                        }
-                    });
+                    manager.0.write().await.insert(id, writer);
+                    spawn_read(reader, on_message, manager.clone());
                     Ok(id)
                 } else {
                     log::error!("missing socket path parameter");

--- a/crates/tauri-plugin-mihomo/src/mihomo.rs
+++ b/crates/tauri-plugin-mihomo/src/mihomo.rs
@@ -19,9 +19,10 @@ use crate::{
     models::{
         BaseConfig, CloseFrame, ConnectionManager, Connections, CoreUpdaterChannel, ErrorResponse, Groups, LogLevel,
         MihomoVersion, Protocol, Proxies, Proxy, ProxyDelay, ProxyProvider, ProxyProviders, RuleProviders, Rules,
-        WebSocketConnectionId, WebSocketMessage, WsReadeKind, WsStream,
+        WebSocketConnectionId, WebSocketMessage,
     },
     ret_failed_resp,
+    stream::{WsReadeKind, WsStream},
 };
 
 pub struct Mihomo {
@@ -179,7 +180,7 @@ impl Mihomo {
                     code: v.code.into(),
                     reason: v.reason.to_string(),
                 })))?,
-                Ok(Message::Frame(_)) => serde_json::Value::Null, // This value can't be received.;
+                Ok(Message::Frame(_)) => serde_json::Value::Null, // This value can't be received.
                 Err(e) => {
                     log::error!("websocket error: {e}");
                     serde_json::to_value(WebSocketMessage::Text(e.to_string()))?
@@ -191,27 +192,22 @@ impl Mihomo {
         let spawn_read = move |mut reader: WsReadeKind, on_message: F, manager: Arc<ConnectionManager>| {
             tokio::spawn(async move {
                 let manager_ = manager.clone();
-                loop {
-                    let ids: Vec<u32> = manager_.0.read().await.keys().cloned().collect();
-                    if !ids.contains(&id) {
+                while let Some(message) = reader.next().await {
+                    if !manager_.0.read().await.contains_key(&id) {
                         log::debug!("connection [{id}] is removed from manager");
                         break;
                     }
-                    while let Some(message) = reader.next().await {
-                        let ids: Vec<u32> = manager_.0.read().await.keys().cloned().collect();
-                        if !ids.contains(&id) {
-                            log::debug!("connection [{id}] is removed from manager");
-                            break;
-                        }
-                        if let Ok(Message::Close(_)) = message {
-                            log::debug!("connection [{id}] is closed");
-                            manager_.0.write().await.remove(&id);
-                        }
-                        if let Ok(response) = handle_message(message) {
-                            on_message(response);
-                        }
+                    let is_close = matches!(&message, Ok(Message::Close(_)));
+                    if let Ok(response) = handle_message(message) {
+                        on_message(response);
+                    }
+                    if is_close {
+                        log::debug!("connection [{id}] is closed");
+                        manager_.0.write().await.remove(&id);
+                        break;
                     }
                 }
+                manager_.0.write().await.remove(&id);
             });
         };
 
@@ -230,7 +226,7 @@ impl Mihomo {
             Protocol::LocalSocket => {
                 if let Some(socket_path) = self.socket_path.as_ref() {
                     log::debug!("starting connect to websocket by using local socket: {socket_path}");
-                    let stream = crate::wrap_stream::connect_to_socket(socket_path).await?;
+                    let stream = crate::stream::connect_to_socket(socket_path).await?;
 
                     let request = Request::builder()
                         .uri(url)

--- a/crates/tauri-plugin-mihomo/src/mihomo.rs
+++ b/crates/tauri-plugin-mihomo/src/mihomo.rs
@@ -22,7 +22,7 @@ use crate::{
         WebSocketConnectionId, WebSocketMessage,
     },
     ret_failed_resp,
-    stream::{WsReadeKind, WsStream},
+    stream::{WsReadKind, WsStream},
 };
 
 pub struct Mihomo {
@@ -189,7 +189,7 @@ impl Mihomo {
             Ok(msg)
         };
 
-        let spawn_read = move |mut reader: WsReadeKind, on_message: F, manager: Arc<ConnectionManager>| {
+        let spawn_read = move |mut reader: WsReadKind, on_message: F, manager: Arc<ConnectionManager>| {
             tokio::spawn(async move {
                 let manager_ = manager.clone();
                 while let Some(message) = reader.next().await {
@@ -203,7 +203,6 @@ impl Mihomo {
                     }
                     if is_close {
                         log::debug!("connection [{id}] is closed");
-                        manager_.0.write().await.remove(&id);
                         break;
                     }
                 }

--- a/crates/tauri-plugin-mihomo/src/models.rs
+++ b/crates/tauri-plugin-mihomo/src/models.rs
@@ -1,15 +1,10 @@
 use std::{collections::HashMap, fmt::Display};
 
-use futures_util::{
-    SinkExt, StreamExt,
-    stream::{SplitSink, SplitStream},
-};
 use serde::{Deserialize, Serialize};
-use tokio::{net::TcpStream, sync::RwLock};
-use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, tungstenite::Message};
+use tokio::sync::RwLock;
 use ts_rs::TS;
 
-use crate::wrap_stream::SocketStreamKind;
+use crate::stream::WsWriteKind;
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -889,72 +884,6 @@ pub enum WebSocketMessage {
 }
 
 pub type WebSocketConnectionId = u32;
-pub enum WsStream {
-    Tcp(WebSocketStream<MaybeTlsStream<TcpStream>>),
-    Socket(WebSocketStream<SocketStreamKind>),
-}
-
-impl From<WebSocketStream<MaybeTlsStream<TcpStream>>> for WsStream {
-    fn from(value: WebSocketStream<MaybeTlsStream<TcpStream>>) -> Self {
-        WsStream::Tcp(value)
-    }
-}
-
-impl From<WebSocketStream<SocketStreamKind>> for WsStream {
-    fn from(value: WebSocketStream<SocketStreamKind>) -> Self {
-        WsStream::Socket(value)
-    }
-}
-
-impl WsStream {
-    pub fn split(self) -> (WsWriteKind, WsReadeKind) {
-        match self {
-            Self::Tcp(stream) => {
-                let (write, read) = stream.split();
-                (WsWriteKind::Tcp(write), WsReadeKind::Tcp(read))
-            }
-            Self::Socket(stream) => {
-                let (write, read) = stream.split();
-                (WsWriteKind::Socket(write), WsReadeKind::Socket(read))
-            }
-        }
-    }
-}
-
-pub enum WsReadeKind {
-    Tcp(SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>),
-    Socket(SplitStream<WebSocketStream<SocketStreamKind>>),
-}
-
-impl WsReadeKind {
-    pub async fn next(&mut self) -> Option<crate::Result<Message>> {
-        match self {
-            Self::Tcp(read) => read
-                .next()
-                .await
-                .map_or_else(|| None, |v| Some(v.map_err(|e| e.into()))),
-            Self::Socket(read) => read
-                .next()
-                .await
-                .map_or_else(|| None, |v| Some(v.map_err(|e| e.into()))),
-        }
-    }
-}
-
-pub enum WsWriteKind {
-    Tcp(SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>),
-    Socket(SplitSink<WebSocketStream<SocketStreamKind>, Message>),
-}
-
-impl WsWriteKind {
-    pub async fn send(&mut self, message: Message) -> crate::Result<()> {
-        match self {
-            Self::Tcp(write) => write.send(message).await?,
-            Self::Socket(write) => write.send(message).await?,
-        }
-        Ok(())
-    }
-}
 
 #[derive(Default)]
 pub struct ConnectionManager(pub RwLock<HashMap<WebSocketConnectionId, WsWriteKind>>);

--- a/crates/tauri-plugin-mihomo/src/models.rs
+++ b/crates/tauri-plugin-mihomo/src/models.rs
@@ -1,12 +1,15 @@
 use std::{collections::HashMap, fmt::Display};
 
-use futures_util::{SinkExt, stream::SplitSink};
+use futures_util::{
+    SinkExt, StreamExt,
+    stream::{SplitSink, SplitStream},
+};
 use serde::{Deserialize, Serialize};
 use tokio::{net::TcpStream, sync::RwLock};
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, tungstenite::Message};
 use ts_rs::TS;
 
-use crate::wrap_stream::WrapStream;
+use crate::wrap_stream::SocketStreamKind;
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -886,24 +889,72 @@ pub enum WebSocketMessage {
 }
 
 pub type WebSocketConnectionId = u32;
-pub enum WebSocketWriter {
-    TcpStreamWriter(SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>),
-    SocketStreamWriter(SplitSink<WebSocketStream<WrapStream>, Message>),
+pub enum WsStream {
+    Tcp(WebSocketStream<MaybeTlsStream<TcpStream>>),
+    Socket(WebSocketStream<SocketStreamKind>),
 }
 
-impl WebSocketWriter {
+impl From<WebSocketStream<MaybeTlsStream<TcpStream>>> for WsStream {
+    fn from(value: WebSocketStream<MaybeTlsStream<TcpStream>>) -> Self {
+        WsStream::Tcp(value)
+    }
+}
+
+impl From<WebSocketStream<SocketStreamKind>> for WsStream {
+    fn from(value: WebSocketStream<SocketStreamKind>) -> Self {
+        WsStream::Socket(value)
+    }
+}
+
+impl WsStream {
+    pub fn split(self) -> (WsWriteKind, WsReadeKind) {
+        match self {
+            Self::Tcp(stream) => {
+                let (write, read) = stream.split();
+                (WsWriteKind::Tcp(write), WsReadeKind::Tcp(read))
+            }
+            Self::Socket(stream) => {
+                let (write, read) = stream.split();
+                (WsWriteKind::Socket(write), WsReadeKind::Socket(read))
+            }
+        }
+    }
+}
+
+pub enum WsReadeKind {
+    Tcp(SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>),
+    Socket(SplitStream<WebSocketStream<SocketStreamKind>>),
+}
+
+impl WsReadeKind {
+    pub async fn next(&mut self) -> Option<crate::Result<Message>> {
+        match self {
+            Self::Tcp(read) => read
+                .next()
+                .await
+                .map_or_else(|| None, |v| Some(v.map_err(|e| e.into()))),
+            Self::Socket(read) => read
+                .next()
+                .await
+                .map_or_else(|| None, |v| Some(v.map_err(|e| e.into()))),
+        }
+    }
+}
+
+pub enum WsWriteKind {
+    Tcp(SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>),
+    Socket(SplitSink<WebSocketStream<SocketStreamKind>, Message>),
+}
+
+impl WsWriteKind {
     pub async fn send(&mut self, message: Message) -> crate::Result<()> {
         match self {
-            WebSocketWriter::TcpStreamWriter(write) => {
-                write.send(message).await?;
-            }
-            WebSocketWriter::SocketStreamWriter(write) => {
-                write.send(message).await?;
-            }
+            Self::Tcp(write) => write.send(message).await?,
+            Self::Socket(write) => write.send(message).await?,
         }
         Ok(())
     }
 }
 
 #[derive(Default)]
-pub struct ConnectionManager(pub RwLock<HashMap<WebSocketConnectionId, WebSocketWriter>>);
+pub struct ConnectionManager(pub RwLock<HashMap<WebSocketConnectionId, WsWriteKind>>);

--- a/crates/tauri-plugin-mihomo/src/stream.rs
+++ b/crates/tauri-plugin-mihomo/src/stream.rs
@@ -40,26 +40,26 @@ impl From<WebSocketStream<SocketStreamKind>> for WsStream {
 }
 
 impl WsStream {
-    pub fn split(self) -> (WsWriteKind, WsReadeKind) {
+    pub fn split(self) -> (WsWriteKind, WsReadKind) {
         match self {
             Self::Tcp(stream) => {
                 let (write, read) = stream.split();
-                (WsWriteKind::Tcp(write), WsReadeKind::Tcp(read))
+                (WsWriteKind::Tcp(write), WsReadKind::Tcp(read))
             }
             Self::Socket(stream) => {
                 let (write, read) = stream.split();
-                (WsWriteKind::Socket(write), WsReadeKind::Socket(read))
+                (WsWriteKind::Socket(write), WsReadKind::Socket(read))
             }
         }
     }
 }
 
-pub enum WsReadeKind {
+pub enum WsReadKind {
     Tcp(SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>),
     Socket(SplitStream<WebSocketStream<SocketStreamKind>>),
 }
 
-impl WsReadeKind {
+impl WsReadKind {
     pub async fn next(&mut self) -> Option<crate::Result<Message>> {
         match self {
             Self::Tcp(read) => read.next().await.map(|v| v.map_err(Into::into)),

--- a/crates/tauri-plugin-mihomo/src/stream.rs
+++ b/crates/tauri-plugin-mihomo/src/stream.rs
@@ -3,16 +3,85 @@ use std::{
     task::{Context, Poll},
 };
 
+use futures_util::{
+    SinkExt, StreamExt,
+    stream::{SplitSink, SplitStream},
+};
 use pin_project::pin_project;
-use tokio::io::{AsyncRead, AsyncWrite};
 #[cfg(unix)]
 use tokio::net::UnixStream;
 #[cfg(windows)]
 use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeClient};
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    net::TcpStream,
+};
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, tungstenite::Message};
 #[cfg(windows)]
 use windows_sys::Win32::Foundation::ERROR_PIPE_BUSY;
 
 use crate::{Error, Result};
+
+pub enum WsStream {
+    Tcp(WebSocketStream<MaybeTlsStream<TcpStream>>),
+    Socket(WebSocketStream<SocketStreamKind>),
+}
+
+impl From<WebSocketStream<MaybeTlsStream<TcpStream>>> for WsStream {
+    fn from(value: WebSocketStream<MaybeTlsStream<TcpStream>>) -> Self {
+        WsStream::Tcp(value)
+    }
+}
+
+impl From<WebSocketStream<SocketStreamKind>> for WsStream {
+    fn from(value: WebSocketStream<SocketStreamKind>) -> Self {
+        WsStream::Socket(value)
+    }
+}
+
+impl WsStream {
+    pub fn split(self) -> (WsWriteKind, WsReadeKind) {
+        match self {
+            Self::Tcp(stream) => {
+                let (write, read) = stream.split();
+                (WsWriteKind::Tcp(write), WsReadeKind::Tcp(read))
+            }
+            Self::Socket(stream) => {
+                let (write, read) = stream.split();
+                (WsWriteKind::Socket(write), WsReadeKind::Socket(read))
+            }
+        }
+    }
+}
+
+pub enum WsReadeKind {
+    Tcp(SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>),
+    Socket(SplitStream<WebSocketStream<SocketStreamKind>>),
+}
+
+impl WsReadeKind {
+    pub async fn next(&mut self) -> Option<crate::Result<Message>> {
+        match self {
+            Self::Tcp(read) => read.next().await.map(|v| v.map_err(Into::into)),
+            Self::Socket(read) => read.next().await.map(|v| v.map_err(Into::into)),
+        }
+    }
+}
+
+pub enum WsWriteKind {
+    Tcp(SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>),
+    Socket(SplitSink<WebSocketStream<SocketStreamKind>, Message>),
+}
+
+impl WsWriteKind {
+    pub async fn send(&mut self, message: Message) -> crate::Result<()> {
+        match self {
+            Self::Tcp(write) => write.send(message).await?,
+            Self::Socket(write) => write.send(message).await?,
+        }
+        Ok(())
+    }
+}
 
 #[pin_project(project = WrapStreamProj)]
 pub enum SocketStreamKind {

--- a/crates/tauri-plugin-mihomo/src/wrap_stream.rs
+++ b/crates/tauri-plugin-mihomo/src/wrap_stream.rs
@@ -15,14 +15,14 @@ use windows_sys::Win32::Foundation::ERROR_PIPE_BUSY;
 use crate::{Error, Result};
 
 #[pin_project(project = WrapStreamProj)]
-pub enum WrapStream {
+pub enum SocketStreamKind {
     #[cfg(unix)]
     Unix(#[pin] UnixStream),
     #[cfg(windows)]
     NamedPipe(#[pin] NamedPipeClient),
 }
 
-impl AsyncRead for WrapStream {
+impl AsyncRead for SocketStreamKind {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -37,7 +37,7 @@ impl AsyncRead for WrapStream {
     }
 }
 
-impl AsyncWrite for WrapStream {
+impl AsyncWrite for SocketStreamKind {
     fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<std::io::Result<usize>> {
         match self.project() {
             #[cfg(unix)]
@@ -66,7 +66,7 @@ impl AsyncWrite for WrapStream {
     }
 }
 
-pub async fn connect_to_socket(socket_path: &str) -> Result<WrapStream> {
+pub async fn connect_to_socket(socket_path: &str) -> Result<SocketStreamKind> {
     #[cfg(unix)]
     {
         if !std::path::Path::new(socket_path).exists() {
@@ -76,7 +76,7 @@ pub async fn connect_to_socket(socket_path: &str) -> Result<WrapStream> {
                 format!("socket path: {socket_path} not found"),
             )));
         }
-        Ok(WrapStream::Unix(UnixStream::connect(socket_path).await?))
+        Ok(SocketStreamKind::Unix(UnixStream::connect(socket_path).await?))
     }
 
     #[cfg(windows)]
@@ -94,6 +94,6 @@ pub async fn connect_to_socket(socket_path: &str) -> Result<WrapStream> {
             }
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         };
-        Ok(WrapStream::NamedPipe(client))
+        Ok(SocketStreamKind::NamedPipe(client))
     }
 }


### PR DESCRIPTION
## 概述

本PR重构了WebSocket连接处理和流抽象，提升了代码的可维护性和类型安全性。

## 主要改动

### 1. 类型系统重构
- 引入了新的 `WsStream` 枚举类型，统一处理TCP和Socket两种WebSocket连接
- 新增 `WsWriteKind` 和 `WsReadeKind` 类型，分别用于WebSocket的写入和读取操作
- 移除了原来的 `WebSocketWriter` 枚举，改用更清晰的类型层次结构

### 2. 连接管理优化
- 提取了 `spawn_read` 函数来统一处理WebSocket消息读取逻辑
- 统一了HTTP和Unix socket的WebSocket连接处理流程
- 改进了错误处理，使用 `Result` 类型替代 `unwrap()`

### 3. 命名优化
- 将 `WrapStream` 重命名为 `SocketStreamKind`，使命名更加清晰和语义化

## 技术细节

**影响的文件：**
- `crates/tauri-plugin-mihomo/src/mihomo.rs`: 重构了WebSocket连接管理逻辑
- `crates/tauri-plugin-mihomo/src/models.rs`: 新增和重构了WebSocket相关类型定义
- `crates/tauri-plugin-mihomo/src/wrap_stream.rs`: 重命名类型以提升可读性

**改进点：**
- 更好的类型抽象和错误处理
- 减少代码重复，提取公共逻辑
- 提升代码的可读性和可维护性

## 测试建议

- 测试WebSocket连接的建立和关闭
- 验证消息的发送和接收功能
- 检查不同协议（HTTP和Unix socket）下的连接行为