### PR TITLE
feat(macos): support keep_in_dock toggle

### DIFF
--- a/src-tauri/src/config/verge.rs
+++ b/src-tauri/src/config/verge.rs
@@ -67,7 +67,7 @@ pub struct IVerge {
     pub enable_auto_launch: Option<bool>,
 
     /// 是否启用系统标题栏
-    #[serde(alias = "enable_system_title", alias = "enable_system_title_bar")]
+    #[serde(alias = "enable_system_title")]
     pub enable_system_title_bar: Option<bool>,
 
     /// 是否保持UI界面活动
@@ -168,6 +168,7 @@ pub struct IVerge {
     pub enable_tray: Option<bool>,
 
     /// keep in dock
+    #[serde(alias = "show_in_dock")]
     pub keep_in_dock: Option<bool>,
 
     /// enable external controller, such as 127.0.0.1:8080

--- a/src-tauri/src/config/verge.rs
+++ b/src-tauri/src/config/verge.rs
@@ -168,7 +168,6 @@ pub struct IVerge {
     pub enable_tray: Option<bool>,
 
     /// keep in dock
-    #[serde(alias = "show_in_dock")]
     pub keep_in_dock: Option<bool>,
 
     /// enable external controller, such as 127.0.0.1:8080

--- a/src-tauri/src/config/verge.rs
+++ b/src-tauri/src/config/verge.rs
@@ -168,6 +168,7 @@ pub struct IVerge {
     pub enable_tray: Option<bool>,
 
     /// keep in dock
+    #[serde(alias = "show_in_dock")]
     pub keep_in_dock: Option<bool>,
 
     /// enable external controller, such as 127.0.0.1:8080

--- a/src-tauri/src/config/verge.rs
+++ b/src-tauri/src/config/verge.rs
@@ -167,8 +167,8 @@ pub struct IVerge {
     /// enable tray
     pub enable_tray: Option<bool>,
 
-    /// show in dock
-    pub show_in_dock: Option<bool>,
+    /// keep in dock
+    pub keep_in_dock: Option<bool>,
 
     /// enable external controller, such as 127.0.0.1:8080
     pub enable_external_controller: Option<bool>,
@@ -304,7 +304,7 @@ impl IVerge {
             auto_check_update: Some(true),
             auto_log_clean: Some(3),
             enable_tray: Some(true),
-            show_in_dock: Some(true),
+            keep_in_dock: Some(true),
             enable_external_controller: Some(false),
             ..Self::default()
         }
@@ -381,7 +381,7 @@ impl IVerge {
         patch!(webdav_username);
         patch!(webdav_password);
         patch!(enable_tray);
-        patch!(show_in_dock);
+        patch!(keep_in_dock);
         patch!(enable_external_controller);
     }
 

--- a/src-tauri/src/core/handle.rs
+++ b/src-tauri/src/core/handle.rs
@@ -98,14 +98,14 @@ impl Handle {
         Ok(())
     }
 
-    #[cfg(target_os = "macos")]
-    pub fn set_dock_visible(visible: bool) -> AppResult<()> {
-        log_err!(
-            Self::app_handle().set_dock_visibility(visible),
-            "failed to set visible in macos dock"
-        );
-        Ok(())
-    }
+    // #[cfg(target_os = "macos")]
+    // pub fn set_dock_visible(visible: bool) -> AppResult<()> {
+    //     log_err!(
+    //         Self::app_handle().set_dock_visibility(visible),
+    //         "failed to set visible in macos dock"
+    //     );
+    //     Ok(())
+    // }
 
     pub fn notify<T: Into<String>, B: Into<String>>(title: T, body: B) {
         let notification = Self::app_handle().notification().builder().title(title).body(body);

--- a/src-tauri/src/core/handle.rs
+++ b/src-tauri/src/core/handle.rs
@@ -98,15 +98,6 @@ impl Handle {
         Ok(())
     }
 
-    // #[cfg(target_os = "macos")]
-    // pub fn set_dock_visible(visible: bool) -> AppResult<()> {
-    //     log_err!(
-    //         Self::app_handle().set_dock_visibility(visible),
-    //         "failed to set visible in macos dock"
-    //     );
-    //     Ok(())
-    // }
-
     pub fn notify<T: Into<String>, B: Into<String>>(title: T, body: B) {
         let notification = Self::app_handle().notification().builder().title(title).body(body);
         log_err!(notification.show(), "failed to show notification");

--- a/src-tauri/src/enhance/script.rs
+++ b/src-tauri/src/enhance/script.rs
@@ -69,6 +69,7 @@ pub fn use_script(script: String, config: Mapping) -> AppResult<(Mapping, Vec<Lo
         }
         let res: AppResult<Mapping> = Ok(serde_json::from_str::<Mapping>(result.as_str())?);
         let mut out = outputs.lock().unwrap();
+        drop(context);
         match res {
             Ok(config) => Ok((use_lowercase(config), out.to_vec())),
             Err(err) => {
@@ -81,6 +82,7 @@ pub fn use_script(script: String, config: Mapping) -> AppResult<(Mapping, Vec<Lo
             }
         }
     } else {
+        drop(context);
         Err(any_err!("main function should return object"))
     }
 }

--- a/src-tauri/src/enhance/script.rs
+++ b/src-tauri/src/enhance/script.rs
@@ -69,7 +69,6 @@ pub fn use_script(script: String, config: Mapping) -> AppResult<(Mapping, Vec<Lo
         }
         let res: AppResult<Mapping> = Ok(serde_json::from_str::<Mapping>(result.as_str())?);
         let mut out = outputs.lock().unwrap();
-        drop(context);
         match res {
             Ok(config) => Ok((use_lowercase(config), out.to_vec())),
             Err(err) => {
@@ -82,7 +81,6 @@ pub fn use_script(script: String, config: Mapping) -> AppResult<(Mapping, Vec<Lo
             }
         }
     } else {
-        drop(context);
         Err(any_err!("main function should return object"))
     }
 }

--- a/src-tauri/src/feat.rs
+++ b/src-tauri/src/feat.rs
@@ -443,8 +443,6 @@ pub async fn patch_verge(patch: IVerge) -> AppResult<()> {
         let log_level = patch.app_log_level;
         let enable_tray = patch.enable_tray;
         let service_mode = patch.enable_service_mode;
-        #[cfg(target_os = "macos")]
-        let show_in_dock = patch.show_in_dock;
 
         if let Some(enable_external_controller) = enable_external_controller {
             tracing::info!("enable external controller: {enable_external_controller}");
@@ -515,12 +513,6 @@ pub async fn patch_verge(patch: IVerge) -> AppResult<()> {
         if let Some(enable_tray) = enable_tray {
             tracing::debug!("toggle tray enable: {enable_tray}");
             handle::Handle::set_tray_visible(enable_tray)?;
-        }
-
-        #[cfg(target_os = "macos")]
-        if let Some(show_in_dock) = show_in_dock {
-            tracing::debug!("toggle show in macos dock, {show_in_dock}");
-            handle::Handle::set_dock_visible(show_in_dock)?;
         }
 
         Ok(())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -107,14 +107,14 @@ pub fn run() -> AppResult<()> {
                 .set(app_handle.clone())
                 .expect("failed to set global app handle");
 
-            #[cfg(target_os = "macos")]
-            {
-                let _ = app_handle.set_activation_policy(tauri::ActivationPolicy::Regular);
-                let show_in_dock = Config::verge().latest().show_in_dock.unwrap_or(true);
-                if !show_in_dock {
-                    let _ = app_handle.set_dock_visibility(false);
-                }
-            }
+            // #[cfg(target_os = "macos")]
+            // {
+            //     let _ = app_handle.set_activation_policy(tauri::ActivationPolicy::Regular);
+            //     let show_in_dock = Config::verge().latest().show_in_dock.unwrap_or(true);
+            //     if !show_in_dock {
+            //         let _ = app_handle.set_dock_visibility(false);
+            //     }
+            // }
 
             let version = app_handle.package_info().version.to_string();
             app_handle.manage(AppState {
@@ -218,7 +218,12 @@ pub fn run() -> AppResult<()> {
                             resolve::save_window_size_position(app_handle),
                             "save window size position failed"
                         );
-                        resolve::handle_window_close(api, app_handle)
+                        resolve::handle_window_close(api, app_handle);
+                        #[cfg(target_os = "macos")]
+                        {
+                            let dock_visible: bool = Config::verge().latest().show_in_dock.unwrap_or(true);
+                            resolve::apply_tray_policy(app_handle, dock_visible);
+                        }
                     }
                     _ => {}
                 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -107,15 +107,6 @@ pub fn run() -> AppResult<()> {
                 .set(app_handle.clone())
                 .expect("failed to set global app handle");
 
-            // #[cfg(target_os = "macos")]
-            // {
-            //     let _ = app_handle.set_activation_policy(tauri::ActivationPolicy::Regular);
-            //     let show_in_dock = Config::verge().latest().show_in_dock.unwrap_or(true);
-            //     if !show_in_dock {
-            //         let _ = app_handle.set_dock_visibility(false);
-            //     }
-            // }
-
             let version = app_handle.package_info().version.to_string();
             app_handle.manage(AppState {
                 app_version: version,
@@ -221,7 +212,7 @@ pub fn run() -> AppResult<()> {
                         resolve::handle_window_close(api, app_handle);
                         #[cfg(target_os = "macos")]
                         {
-                            let dock_visible: bool = Config::verge().latest().show_in_dock.unwrap_or(true);
+                            let dock_visible: bool = Config::verge().latest().keep_in_dock.unwrap_or(true);
                             resolve::apply_tray_policy(app_handle, dock_visible);
                         }
                     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -107,6 +107,14 @@ pub fn run() -> AppResult<()> {
                 .set(app_handle.clone())
                 .expect("failed to set global app handle");
 
+            #[cfg(target_os = "macos")]
+            {
+                if resolve::is_silent_start() {
+                    let dock_visible: bool = Config::verge().latest().keep_in_dock.unwrap_or(true);
+                    resolve::apply_tray_policy(app_handle, dock_visible);
+                }
+            }
+
             let version = app_handle.package_info().version.to_string();
             app_handle.manage(AppState {
                 app_version: version,

--- a/src-tauri/src/utils/resolve.rs
+++ b/src-tauri/src/utils/resolve.rs
@@ -138,6 +138,10 @@ pub fn create_window() {
         trace_err!(window.unminimize(), "set win unminimize");
         trace_err!(window.show(), "set win visible");
         trace_err!(window.set_focus(), "set win focus");
+        #[cfg(target_os = "macos")]
+        {
+            apply_tray_policy(app_handle, true);
+        }
         return;
     }
 

--- a/src-tauri/src/utils/resolve.rs
+++ b/src-tauri/src/utils/resolve.rs
@@ -52,23 +52,20 @@ pub async fn resolve_setup() {
         create_window();
     }
 
-    let process_silent_start = || {
-        let silent_start = Config::verge().latest().silent_start_mode.clone().unwrap_or_default();
-        if matches!(silent_start, SilentStartMode::Bootup | SilentStartMode::Off) {
-            create_window();
-        }
-    };
-
     let argvs = std::env::args().collect::<Vec<String>>();
     if let [_, second, ..] = argvs.as_slice() {
         if second.as_str() == "--hidden" {
             tracing::debug!("silent start app at boot-up");
         } else if second.starts_with("clash:") {
-            process_silent_start();
+            if !is_silent_start() {
+                create_window();
+            }
             resolve_scheme(second.to_owned()).await;
         }
     } else {
-        process_silent_start();
+        if !is_silent_start() {
+            create_window();
+        }
     }
 }
 
@@ -301,6 +298,14 @@ pub fn handle_window_close(api: CloseRequestApi, app_handle: &AppHandle) {
         }
         api.prevent_close();
     }
+}
+
+pub fn is_silent_start() -> bool {
+    let env = handle::Handle::app_handle().env().clone();
+    let is_bootup_silent = env.args_os.iter().any(|i| i == "--hidden");
+    let silent_start = Config::verge().latest().silent_start_mode.clone().unwrap_or_default();
+    matches!(silent_start, SilentStartMode::Bootup) && is_bootup_silent
+        || matches!(silent_start, SilentStartMode::Global)
 }
 
 #[cfg(target_os = "macos")]

--- a/src-tauri/src/utils/resolve.rs
+++ b/src-tauri/src/utils/resolve.rs
@@ -301,7 +301,7 @@ pub fn handle_window_close(api: CloseRequestApi, app_handle: &AppHandle) {
 }
 
 pub fn is_silent_start() -> bool {
-    let env = handle::Handle::app_handle().env().clone();
+    let env = handle::Handle::app_handle().env();
     let is_bootup_silent = env.args_os.iter().any(|i| i == "--hidden");
     let silent_start = Config::verge().latest().silent_start_mode.clone().unwrap_or_default();
     matches!(silent_start, SilentStartMode::Bootup) && is_bootup_silent

--- a/src-tauri/src/utils/resolve.rs
+++ b/src-tauri/src/utils/resolve.rs
@@ -218,6 +218,11 @@ pub fn create_window() {
             }
             #[cfg(debug_assertions)]
             win.open_devtools();
+
+            #[cfg(target_os = "macos")]
+            {
+                apply_tray_policy(app_handle, true);
+            }
         }
         Err(e) => {
             tracing::error!("failed to create window: {e}");
@@ -295,5 +300,20 @@ pub fn handle_window_close(api: CloseRequestApi, app_handle: &AppHandle) {
             let _ = window.hide();
         }
         api.prevent_close();
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub fn apply_tray_policy(app: &tauri::AppHandle, dock_visible: bool) {
+    if let Err(err) = app.set_dock_visibility(dock_visible) {
+        tracing::warn!("set dock visibility failed: {err}");
+    }
+    let policy = if dock_visible {
+        tauri::ActivationPolicy::Regular
+    } else {
+        tauri::ActivationPolicy::Accessory
+    };
+    if let Err(err) = app.set_activation_policy(policy) {
+        tracing::warn!("set activation policy failed: {err}");
     }
 }

--- a/src/components/setting/mods/layout-viewer.tsx
+++ b/src/components/setting/mods/layout-viewer.tsx
@@ -118,7 +118,21 @@ export const LayoutViewer = forwardRef<DialogRef>((props, ref) => {
 
         {OS === "macos" && (
           <Item>
-            <ListItemText primary={t("Show In Dock")} />
+            <ListItemText
+              primary={
+                <Box sx={{ display: "flex", alignItems: "center" }}>
+                  <span>{t("Keep In Dock")}</span>
+                  <Tooltip title={t("Keep In Dock Info")} placement="top">
+                    <IconButton color="inherit" size="small">
+                      <InfoRounded
+                        fontSize="inherit"
+                        style={{ cursor: "pointer", opacity: 0.75 }}
+                      />
+                    </IconButton>
+                  </Tooltip>
+                </Box>
+              }
+            />
             <GuardState
               value={verge?.show_in_dock ?? true}
               valueProps="checked"

--- a/src/components/setting/mods/layout-viewer.tsx
+++ b/src/components/setting/mods/layout-viewer.tsx
@@ -134,12 +134,12 @@ export const LayoutViewer = forwardRef<DialogRef>((props, ref) => {
               }
             />
             <GuardState
-              value={verge?.show_in_dock ?? true}
+              value={verge?.keep_in_dock ?? true}
               valueProps="checked"
               onCatch={onError}
               onFormat={onSwitchFormat}
-              onChange={(e) => onChangeData({ show_in_dock: e })}
-              onGuard={(e) => patchVerge({ show_in_dock: e })}>
+              onChange={(e) => onChangeData({ keep_in_dock: e })}
+              onGuard={(e) => patchVerge({ keep_in_dock: e })}>
               <SwitchLovely edge="end" />
             </GuardState>
           </Item>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -297,7 +297,8 @@
 
   "Splashscreen": "Splash Screen",
   "System Title Bar": "System Title Bar",
-  "Show In Dock": "Show In Dock",
+  "Keep In Dock": "Keep in Dock",
+  "Keep In Dock Info": "The application icon remains in the dock after the application window is closed",
   "Keep UI Active": "Keep UI Active",
   "Keep UI Active Info": "Keep the UI active and open it again without re-rendering the interface",
   "From": "From",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -297,7 +297,8 @@
 
   "Splashscreen": "启动页",
   "System Title Bar": "系统标题栏",
-  "Show In Dock": "在程序坞中显示",
+  "Keep In Dock": "在程序坞中保留",
+  "Keep In Dock Info": "应用程序图标在关闭应用程序窗口后仍保留在停靠栏中",
   "Keep UI Active": "保持UI界面活动",
   "Keep UI Active Info": "保持UI界面活动，再次打开无需重新渲染界面",
   "From": "来自",

--- a/src/services/types.d.ts
+++ b/src/services/types.d.ts
@@ -312,7 +312,7 @@ interface IVergeConfig {
   webdav_username?: string;
   webdav_password?: string;
   enable_tray?: boolean;
-  show_in_dock?: boolean;
+  keep_in_dock?: boolean;
   enable_external_controller?: boolean;
 }
 


### PR DESCRIPTION
概述

启用 macOS 停靠栏（Dock）显示切换，新增/使用配置项 `keep_in_dock` 控制应用图标在 Dock 的显示与否。同时对启动时的激活策略与托盘/窗口逻辑做了简化，并修复了一处脚本中的冗余资源释放（移除多余的 `drop` 调用）。

要点（简短）

- 支持通过配置切换 Dock 可见性（`keep_in_dock`）。
- 调整激活策略以配合 Dock 行为。
- 简化托盘/窗口相关逻辑。
- 小范围脚本清理修复。

验证建议

在 macOS 上切换配置并确认 Dock 图标显示行为符合预期。