### PR TITLE
refactor(swr): centralize SWR keys and hooks

### DIFF
--- a/src/components/layout/update-button.tsx
+++ b/src/components/layout/update-button.tsx
@@ -1,7 +1,6 @@
-import { check } from "@tauri-apps/plugin-updater";
 import React, { Suspense, useRef } from "react";
-import useSWR from "swr";
 
+import { useCheckUpdateSWR } from "@/services/swr";
 import { useVergeStore } from "@/stores";
 
 import { DialogRef } from "../base";
@@ -24,15 +23,7 @@ export const UpdateButton = (props: Props) => {
 
   const viewerRef = useRef<DialogRef>(null);
 
-  const { data: updateInfo } = useSWR(
-    autoCheckUpdate ? "checkUpdate" : null,
-    check,
-    {
-      errorRetryCount: 2,
-      revalidateIfStale: false,
-      focusThrottleInterval: 36e5, // 1 hour
-    },
-  );
+  const { data: updateInfo } = useCheckUpdateSWR(autoCheckUpdate);
 
   if (!updateInfo) return null;
 

--- a/src/components/proxy/provider-button.tsx
+++ b/src/components/proxy/provider-button.tsx
@@ -13,10 +13,9 @@ import dayjs from "dayjs";
 import { throttle } from "lodash-es";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import useSWR, { mutate } from "swr";
 import { updateProxyProvider } from "tauri-plugin-mihomo-api";
 
-import { calcuProxyProviders } from "@/services/api";
+import { mutate, swrKeys, useProxyProvidersSWR } from "@/services/swr";
 import { cn } from "@/utils";
 import parseTraffic from "@/utils/parse-traffic";
 
@@ -24,10 +23,7 @@ import { BaseDialog } from "../base";
 
 export const ProviderButton = () => {
   const { t } = useTranslation();
-  const { data = {}, mutate: mutateProxyProviders } = useSWR(
-    "getProxyProviders",
-    calcuProxyProviders,
-  );
+  const { data = {}, mutate: mutateProxyProviders } = useProxyProvidersSWR();
   const entries = Object.entries(data);
   const keys = entries.map(([key]) => key);
 
@@ -56,13 +52,13 @@ export const ProviderButton = () => {
   const updateAll = throttle(async () => {
     const tasks = keys.map((key, index) => handleUpdate(key, index));
     await Promise.all(tasks);
-    mutate("getProxies");
+    mutate(swrKeys.proxies);
     mutateProxyProviders();
   }, 1000);
 
   const updateOne = throttle(async (key: string) => {
     await handleUpdate(key, keys.indexOf(key));
-    mutate("getProxies");
+    mutate(swrKeys.proxies);
     mutateProxyProviders();
   }, 1000);
 

--- a/src/components/proxy/use-render-list.ts
+++ b/src/components/proxy/use-render-list.ts
@@ -1,8 +1,7 @@
 import { useEffect, useMemo } from "react";
-import useSWR from "swr";
 
 import { useWindowSize } from "@/hooks/use-window-size";
-import { calcuProxies } from "@/services/api";
+import { useProxiesSWR } from "@/services/swr";
 import { useProfilesStore, useVergeStore } from "@/stores";
 import type { HeadState } from "@/stores/proxyHeadStateStore";
 import {
@@ -24,11 +23,7 @@ export interface IRenderItem {
 }
 
 export const useRenderList = (mode: string) => {
-  const { data: proxiesData, mutate: mutateProxies } = useSWR(
-    "getProxies",
-    calcuProxies,
-    { refreshInterval: 45000 },
-  );
+  const { data: proxiesData, mutate: mutateProxies } = useProxiesSWR();
 
   const currentProfileUid = useProfilesStore((s) => s.config.current || "");
   const proxyLayoutColumn = useVergeStore(

--- a/src/components/setting/mods/clash-core-viewer.tsx
+++ b/src/components/setting/mods/clash-core-viewer.tsx
@@ -14,7 +14,6 @@ import { debounce } from "lodash-es";
 import { forwardRef, useImperativeHandle, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { PulseLoader } from "react-spinners";
-import { mutate } from "swr";
 import {
   closeAllConnections,
   MihomoWebSocket,
@@ -85,10 +84,6 @@ export const ClashCoreViewer = forwardRef<DialogRef, Props>((_props, ref) => {
       await changeClashCore(core);
       patchVerge({ clash_core: core });
       await MihomoWebSocket.cleanupAll();
-      setTimeout(() => {
-        mutate("getClashConfig");
-        mutate("getVersion");
-      }, 1000);
       notice(
         "success",
         t("messages.clash.core.switched", { core: `${core}` }),

--- a/src/components/setting/mods/clash-port-viewer.tsx
+++ b/src/components/setting/mods/clash-port-viewer.tsx
@@ -2,12 +2,12 @@ import { List, ListItem, ListItemText, TextField } from "@mui/material";
 import { useLockFn } from "ahooks";
 import { forwardRef, useImperativeHandle, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { mutate } from "swr";
 
 import { BaseDialog, DialogRef } from "@/components/base";
 import { useNotice } from "@/components/base/notifies";
 import { useClashInfo } from "@/hooks/use-clash";
 import { checkPortAvailable } from "@/services/cmds";
+import { mutate, swrKeys } from "@/services/swr";
 import getSystem from "@/utils/get-system";
 
 const OS = getSystem();
@@ -159,7 +159,7 @@ export const ClashPortViewer = forwardRef<DialogRef>((_props, ref) => {
       }
 
       await patchInfo(updatePorts);
-      await mutate("getRuntimeConfig");
+      await mutate(swrKeys.runtimeConfig);
       setOpen(false);
       notice("success", t("messages.clash.portModified"), 1000);
     } catch (err: any) {

--- a/src/components/setting/mods/update-viewer.tsx
+++ b/src/components/setting/mods/update-viewer.tsx
@@ -1,7 +1,6 @@
 import { Box, Button, LinearProgress } from "@mui/material";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { open as openUrl } from "@tauri-apps/plugin-shell";
-import { check } from "@tauri-apps/plugin-updater";
 import MarkdownPreview from "@uiw/react-markdown-preview";
 import { useLockFn } from "ahooks";
 import React, {
@@ -11,12 +10,12 @@ import React, {
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
-import useSWR from "swr";
 
 import { BaseDialog, DialogRef } from "@/components/base";
 import { useNotice } from "@/components/base/notifies";
 import { usePortable } from "@/hooks/use-portable";
 import { useWindowSize } from "@/hooks/use-window-size";
+import { useCheckUpdateSWR } from "@/services/swr";
 import { useAppUpdatingStore, useThemeModeStore } from "@/stores";
 import getSystem from "@/utils/get-system";
 
@@ -32,11 +31,7 @@ export const UpdateViewer = forwardRef<DialogRef>((_props, ref) => {
   const { size } = useWindowSize();
   const { portable } = usePortable();
 
-  const { data: updateInfo } = useSWR("checkUpdate", check, {
-    errorRetryCount: 2,
-    revalidateIfStale: false,
-    focusThrottleInterval: 36e5, // 1 hour
-  });
+  const { data: updateInfo } = useCheckUpdateSWR();
 
   const [downloaded, setDownloaded] = useState(0);
   const [buffer, setBuffer] = useState(0);

--- a/src/hooks/use-clash.ts
+++ b/src/hooks/use-clash.ts
@@ -1,17 +1,10 @@
 import { useLockFn } from "ahooks";
-import useSWR, { mutate } from "swr";
 
-import {
-  getClashInfo,
-  getRuntimeConfig,
-  patchClashConfig,
-} from "@/services/cmds";
+import { patchClashConfig } from "@/services/cmds";
+import { useClashInfoSWR, useRuntimeConfigSWR } from "@/services/swr";
 
 export const useClash = () => {
-  const { data: clash, mutate: mutateClash } = useSWR(
-    "getRuntimeConfig",
-    getRuntimeConfig,
-  );
+  const { data: clash, mutate: mutateClash } = useRuntimeConfigSWR();
 
   const patchClash = useLockFn(async (patch: Partial<IConfigData>) => {
     await patchClashConfig(patch);
@@ -26,10 +19,7 @@ export const useClash = () => {
 };
 
 export const useClashInfo = () => {
-  const { data: clashInfo, mutate: mutateInfo } = useSWR(
-    "getClashInfo",
-    getClashInfo,
-  );
+  const { data: clashInfo, mutate: mutateInfo } = useClashInfoSWR();
 
   const patchInfo = async (
     patch: Partial<
@@ -99,7 +89,6 @@ export const useClashInfo = () => {
 
     await patchClashConfig(patch);
     mutateInfo();
-    mutate("getClashConfig");
   };
 
   return {

--- a/src/hooks/use-connection-data.ts
+++ b/src/hooks/use-connection-data.ts
@@ -1,8 +1,7 @@
 import { useEffect, useRef } from "react";
-import { mutate } from "swr";
-import useSWRSubscription from "swr/subscription";
 import { MihomoWebSocket } from "tauri-plugin-mihomo-api";
 
+import { mutate, swrSubscriptionKey, useSWRSubscription } from "@/services/swr";
 import { useRefreshConnectionDateStore } from "@/stores";
 
 export type IClosedConnectionItem = IConnectionsItem & {
@@ -132,7 +131,7 @@ export const useConnectionData = () => {
   );
 
   useEffect(() => {
-    mutate(`$sub$${subscriptKey}`);
+    mutate(swrSubscriptionKey(subscriptKey));
   }, [date, subscriptKey]);
 
   const refreshGetClashConnection = () => {
@@ -140,7 +139,7 @@ export const useConnectionData = () => {
   };
 
   const clearClosedConnections = () => {
-    mutate(`$sub$${subscriptKey}`, {
+    mutate(swrSubscriptionKey(subscriptKey), {
       uploadTotal: response.data?.uploadTotal ?? 0,
       downloadTotal: response.data?.downloadTotal ?? 0,
       activeConnections: response.data?.activeConnections ?? [],

--- a/src/hooks/use-log-data.ts
+++ b/src/hooks/use-log-data.ts
@@ -1,10 +1,9 @@
 import dayjs from "dayjs";
 import { useEffect, useRef } from "react";
-import { mutate } from "swr";
-import useSWRSubscription from "swr/subscription";
 import { MihomoWebSocket } from "tauri-plugin-mihomo-api";
 
 import { getClashLogs } from "@/services/cmds";
+import { mutate, swrSubscriptionKey, useSWRSubscription } from "@/services/swr";
 import { useClashLogStore, useRefreshLogsDateStore } from "@/stores";
 
 const MAX_LOG_NUM = 1000;
@@ -129,7 +128,7 @@ export const useLogData = () => {
   );
 
   useEffect(() => {
-    mutate(`$sub$${subscriptKey}`);
+    mutate(swrSubscriptionKey(subscriptKey));
   }, [date, subscriptKey]);
 
   useEffect(() => {
@@ -140,7 +139,7 @@ export const useLogData = () => {
 
   const refreshGetClashLog = (clear = false) => {
     if (clear) {
-      mutate(`$sub$${subscriptKey}`, []);
+      mutate(swrSubscriptionKey(subscriptKey), []);
     } else {
       refresh();
     }

--- a/src/hooks/use-memory-data.ts
+++ b/src/hooks/use-memory-data.ts
@@ -1,8 +1,7 @@
 import { useEffect, useRef } from "react";
-import { mutate } from "swr";
-import useSWRSubscription from "swr/subscription";
 import { MihomoWebSocket } from "tauri-plugin-mihomo-api";
 
+import { mutate, swrSubscriptionKey, useSWRSubscription } from "@/services/swr";
 import { useRefreshMemoryDateStore } from "@/stores";
 
 export const useMemoryData = () => {
@@ -70,7 +69,7 @@ export const useMemoryData = () => {
   );
 
   useEffect(() => {
-    mutate(`$sub$${subscriptKey}`);
+    mutate(swrSubscriptionKey(subscriptKey));
   }, [date, subscriptKey]);
 
   const refreshGetClashMemory = () => {

--- a/src/hooks/use-mihomo-cores-info.ts
+++ b/src/hooks/use-mihomo-cores-info.ts
@@ -1,11 +1,11 @@
 import { Command } from "@tauri-apps/plugin-shell";
 import { useCallback, useEffect } from "react";
-import useSWR from "swr";
 
 import {
   checkPermissionsGranted,
   refreshPermissionsGranted,
 } from "@/services/cmds";
+import { swrKeys, useSWR } from "@/services/swr";
 import { useVergeStore } from "@/stores";
 import getSystem from "@/utils/get-system";
 
@@ -49,7 +49,7 @@ export const useMihomoCoresInfo = () => {
   const enableGrantPermissions = isLinuxPortable && serviceUnavailable;
 
   const { data: mihomoCoresInfo, mutate: muteMihomoCoresInfo } = useSWR(
-    "getMihomoCoresInfo",
+    swrKeys.mihomoCoresInfo,
     async () => {
       let res = defaultValue;
       res = await refreshMihomoVersion(res);

--- a/src/hooks/use-service.ts
+++ b/src/hooks/use-service.ts
@@ -1,16 +1,8 @@
-import useSWR from "swr";
-
-import { checkService } from "@/services/cmds";
+import { useServiceStatusSWR } from "@/services/swr";
 
 export const useService = () => {
-  const { data: serviceStatus, mutate: mutateCheckService } = useSWR<
-    "active" | "installed" | "uninstall" | "unknown"
-  >("checkService", checkService, {
-    revalidateIfStale: false,
-    shouldRetryOnError: false,
-    focusThrottleInterval: 36e5, // 1 hour
-    fallbackData: "uninstall",
-  });
+  const { data: serviceStatus, mutate: mutateCheckService } =
+    useServiceStatusSWR();
 
   return { serviceStatus, mutateCheckService };
 };

--- a/src/hooks/use-traffic-data.ts
+++ b/src/hooks/use-traffic-data.ts
@@ -1,9 +1,8 @@
 import { useEffect, useRef } from "react";
-import { mutate } from "swr";
-import useSWRSubscription from "swr/subscription";
 import { MihomoWebSocket } from "tauri-plugin-mihomo-api";
 
 import { TrafficRef } from "@/components/layout/traffic-graph";
+import { mutate, swrSubscriptionKey, useSWRSubscription } from "@/services/swr";
 import { useRefreshTrafficDateStore } from "@/stores";
 
 export const useTrafficData = () => {
@@ -74,7 +73,7 @@ export const useTrafficData = () => {
   );
 
   useEffect(() => {
-    mutate(`$sub$${subscriptKey}`);
+    mutate(swrSubscriptionKey(subscriptKey));
   }, [date, subscriptKey]);
 
   const refreshGetClashTraffic = () => {

--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -11,7 +11,6 @@ import i18next from "i18next";
 import { debounce } from "lodash-es";
 import { Suspense, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { mutate, SWRConfig } from "swr";
 
 import { TailwindIndicator } from "@/components/base";
 import { useNotice } from "@/components/base/notifies";
@@ -21,7 +20,8 @@ import { useAppHotkeys } from "@/hooks/use-app-hotkeys";
 import { usePortable } from "@/hooks/use-portable";
 import { useVisibility } from "@/hooks/use-visibility";
 import LoadingPage from "@/pages/loading";
-import { useProfilesStore, useVergeStore } from "@/stores";
+import { appSWRConfig, refreshClashSWR, SWRConfig } from "@/services/swr";
+import { useProfilesStore, useRulesStateStore, useVergeStore } from "@/stores";
 import { cn } from "@/utils";
 import getSystem from "@/utils/get-system";
 
@@ -53,6 +53,8 @@ const Layout = () => {
   const hotkeys = useVergeStore((s) => s.verge.hotkeys);
   const refreshVerge = useVergeStore((s) => s.refreshVerge);
   const refreshProfilesConfig = useProfilesStore((s) => s.refreshConfig);
+  const fetchRules = useRulesStateStore((s) => s.fetchRules);
+
   useAppHotkeys(appHotkeys, hotkeys);
   const pathname = useRouterState({
     select: (state) => state.location.pathname,
@@ -84,13 +86,8 @@ const Layout = () => {
 
     const unlistenRefreshClash = listen("verge://refresh-clash-config", () => {
       // the clash info may be updated
-      mutate("getProxies");
-      mutate("getRules");
-      mutate("getVersion");
-      mutate("getClashConfig");
-      mutate("getClashInfo");
-      mutate("getRuntimeConfig");
-      mutate("getProxyProviders");
+      refreshClashSWR();
+      fetchRules();
     });
 
     // update the verge config
@@ -163,13 +160,7 @@ const Layout = () => {
   }, [pathname, pendingPath]);
 
   return (
-    <SWRConfig
-      value={{
-        errorRetryCount: 10,
-        errorRetryInterval: 1000,
-        revalidateOnFocus: true,
-        revalidateOnMount: true,
-      }}>
+    <SWRConfig value={appSWRConfig}>
       <Paper
         square
         elevation={0}

--- a/src/services/swr.ts
+++ b/src/services/swr.ts
@@ -1,0 +1,68 @@
+import { check } from "@tauri-apps/plugin-updater";
+import useBaseSWR, { mutate, SWRConfig, type SWRConfiguration } from "swr";
+import useBaseSWRSubscription from "swr/subscription";
+
+import { calcuProxies, calcuProxyProviders } from "@/services/api";
+import { checkService, getClashInfo, getRuntimeConfig } from "@/services/cmds";
+
+export { mutate, SWRConfig };
+export const useSWR = useBaseSWR;
+export const useSWRSubscription = useBaseSWRSubscription;
+
+export const swrKeys = {
+  checkService: "checkService",
+  checkUpdate: "checkUpdate",
+  clashInfo: "getClashInfo",
+  mihomoCoresInfo: "getMihomoCoresInfo",
+  proxies: "getProxies",
+  proxyProviders: "getProxyProviders",
+  runtimeConfig: "getRuntimeConfig",
+} as const;
+
+export const appSWRConfig: SWRConfiguration = {
+  errorRetryCount: 10,
+  errorRetryInterval: 1000,
+  revalidateOnFocus: true,
+  revalidateOnMount: true,
+};
+
+export const updateSWRConfig: SWRConfiguration = {
+  errorRetryCount: 2,
+  revalidateIfStale: false,
+  focusThrottleInterval: 36e5, // 1 hour
+};
+
+export const swrSubscriptionKey = (key: string | null) => `$sub$${key}`;
+
+export const refreshClashSWR = () => {
+  mutate(swrKeys.proxies);
+  mutate(swrKeys.clashInfo);
+  mutate(swrKeys.runtimeConfig);
+  mutate(swrKeys.proxyProviders);
+};
+
+export const useRuntimeConfigSWR = () =>
+  useSWR(swrKeys.runtimeConfig, getRuntimeConfig);
+
+export const useClashInfoSWR = () => useSWR(swrKeys.clashInfo, getClashInfo);
+
+export const useProxiesSWR = () =>
+  useSWR(swrKeys.proxies, calcuProxies, { refreshInterval: 45000 });
+
+export const useProxyProvidersSWR = () =>
+  useSWR(swrKeys.proxyProviders, calcuProxyProviders);
+
+export const useCheckUpdateSWR = (enabled = true) =>
+  useSWR(enabled ? swrKeys.checkUpdate : null, check, updateSWRConfig);
+
+export const useServiceStatusSWR = () =>
+  useSWR<"active" | "installed" | "uninstall" | "unknown">(
+    swrKeys.checkService,
+    checkService,
+    {
+      revalidateIfStale: false,
+      shouldRetryOnError: false,
+      focusThrottleInterval: 36e5, // 1 hour
+      fallbackData: "uninstall",
+    },
+  );

--- a/src/services/swr.ts
+++ b/src/services/swr.ts
@@ -32,7 +32,7 @@ export const updateSWRConfig: SWRConfiguration = {
   focusThrottleInterval: 36e5, // 1 hour
 };
 
-export const swrSubscriptionKey = (key: string | null) => `$sub$${key}`;
+export const swrSubscriptionKey = (key: string | null) => key ? "$sub$" + key : null;
 
 export const refreshClashSWR = () => {
   mutate(swrKeys.proxies);


### PR DESCRIPTION
## 变更概述
- 新增统一 SWR 入口，集中管理 SWR key、全局配置、mutate、SWRConfig 和订阅 hook 导出
- 将项目内直接从 `swr` / `swr/subscription` 导入的调用点迁移到统一服务文件
- 抽取常用业务 SWR hook，减少组件内重复 key/fetcher 配置
- 删除没有实际 SWR 消费者的遗留 key 和无效 mutate 调用
- 修复日志页暂停后清除按钮无效，以及暂停后 websocket 仍可能继续写入日志的问题

## 主要改动
- 新增 `src/services/swr.ts`，统一导出 `useSWR`、`useSWRSubscription`、`mutate`、`SWRConfig`、`swrKeys` 和常用业务 hook
- 迁移 `use-clash`、`use-service`、`use-mihomo-cores-info`、proxy provider/render list、更新弹窗、layout 等 SWR 使用点
- websocket subscription hooks 继续保留原有连接逻辑，仅统一 `mutate` 与 subscription cache key 入口
- `refreshClashSWR` 统一刷新当前仍有 SWR 消费者的 clash 相关缓存
- 移除 `rules`、`version`、`clashConfig` 三个没有实际 SWR 消费者的 key

## 验证情况
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint src/services/swr.ts src/hooks/use-clash.ts src/components/proxy/use-render-list.ts src/components/proxy/provider-button.tsx src/pages/_layout.tsx src/components/layout/update-button.tsx src/components/setting/mods/update-viewer.tsx src/hooks/use-service.ts src/hooks/use-mihomo-cores-info.ts src/hooks/use-memory-data.ts src/hooks/use-traffic-data.ts src/hooks/use-log-data.ts src/hooks/use-connection-data.ts src/components/setting/mods/clash-core-viewer.tsx src/components/setting/mods/clash-port-viewer.tsx --max-warnings=0`
- `pnpm exec eslint src/hooks/use-log-data.ts src/pages/logs.tsx --max-warnings=0`
- `git diff --check`
- `npx gitnexus detect-changes --scope unstaged`

## 影响范围
- GitNexus detect-changes 对 SWR 集中化报告 MEDIUM：14 files、31 symbols、1 flow
- 日志页暂停/清除修复的 GitNexus 风险为 LOW
- 重点回归代理列表刷新、代理 provider 更新、Clash 配置刷新、更新检查、服务状态、日志/流量/内存/连接 websocket 数据刷新
