### PR TITLE
refactor(profiles): derive profile store state from current profile data

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,7 @@
 import { StyledEngineProvider, ThemeProvider } from "@mui/material";
 import { RouterProvider } from "@tanstack/react-router";
-import { useMount } from "ahooks";
+import { useAsyncEffect, useMount } from "ahooks";
 import { SnackbarProvider } from "notistack";
-import { useEffect } from "react";
 
 import {
   BaseErrorBoundary,
@@ -29,10 +28,9 @@ function App() {
   const { theme } = useCustomTheme();
   // const theme = createTheme({ cssVariables: true });
 
-  useEffect(() => {
-    refreshVerge().then((verge) => {
-      syncThemeSettings(verge);
-    });
+  useAsyncEffect(async () => {
+    const verge = await refreshVerge();
+    syncThemeSettings(verge);
   }, [refreshVerge, syncThemeSettings]);
 
   useMount(async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import {
 import { DragImportOverlay } from "./components/layout/drag-import-overlay";
 import { useCustomTheme } from "./components/layout/use-custom-theme";
 import { router } from "./router";
+import { loadMonaco } from "./services/monaco";
 import {
   useProfilesStore,
   useThemeSettingsStore,
@@ -37,6 +38,7 @@ function App() {
   useMount(async () => {
     await refreshProfilesConfig();
     await refreshChainLogs();
+    await loadMonaco();
   });
 
   return (

--- a/src/components/proxy/proxy-head.tsx
+++ b/src/components/proxy/proxy-head.tsx
@@ -33,7 +33,9 @@ interface Props {
 
 export const ProxyHead = memo(function ProxyHead(props: Props) {
   const { sx = {}, groupName } = props;
-  const currentProfileUid = useProfilesStore((s) => s.config.current || "");
+  const currentProfileUid = useProfilesStore(
+    (s) => s.currentProfile?.uid ?? "",
+  );
   const headState = useProxyHeadStateStore((state) =>
     currentProfileUid
       ? (state.headStates[currentProfileUid]?.[groupName] ?? DEFAULT_STATE)

--- a/src/components/proxy/proxy-render.tsx
+++ b/src/components/proxy/proxy-render.tsx
@@ -104,7 +104,9 @@ export const ProxyRender = memo(function ProxyRender(props: RenderProps) {
   const { item, delayVersion, onLocation, onCheckAll, onChangeProxy } = props;
   const { t } = useTranslation();
   const { type, group, proxy, headState = DEFAULT_STATE } = item;
-  const currentProfileUid = useProfilesStore((s) => s.config.current || "");
+  const currentProfileUid = useProfilesStore(
+    (s) => s.currentProfile?.uid ?? "",
+  );
   const enableGroupIcon = useVergeStore(
     (s) => s.verge.enable_group_icon ?? true,
   );

--- a/src/components/proxy/use-render-list.ts
+++ b/src/components/proxy/use-render-list.ts
@@ -25,7 +25,7 @@ export interface IRenderItem {
 export const useRenderList = (mode: string) => {
   const { data: proxiesData, mutate: mutateProxies } = useProxiesSWR();
 
-  const currentProfileUid = useProfilesStore((s) => s.config.current || "");
+  const currentProfileUid = useProfilesStore((s) => s.currentProfile?.uid);
   const proxyLayoutColumn = useVergeStore(
     (s) => s.verge.proxy_layout_column || 6,
   );

--- a/src/pages/profiles.tsx
+++ b/src/pages/profiles.tsx
@@ -79,11 +79,12 @@ const ProfilePage = () => {
   const [draggingItem, setDraggingItem] = useState<IProfileItem | null>(null);
   const [overItemWidth, setOverItemWidth] = useState(260);
 
-  const config = useProfilesStore((s) => s.config);
+  const currentProfileUid = useProfilesStore((s) => s.currentProfile?.uid);
   const profileItems = useProfilesStore((s) => s.profileItems);
   const globalChainItems = useProfilesStore((s) => s.globalChainItems);
-  const enabledGlobalChainUids = useProfilesStore(
-    (s) => s.enabledGlobalChainUids,
+  const enabledGlobalChainUids = useMemo(
+    () => getEnabledUids(globalChainItems),
+    [globalChainItems],
   );
   const patchConfig = useProfilesStore((s) => s.patchConfig);
   const patchProfile = useProfilesStore((s) => s.patchProfile);
@@ -163,7 +164,7 @@ const ProfilePage = () => {
   );
 
   const onEnhance = useLockFn(async () => {
-    const nextActivatingItemUids = getActivationUids(config.current);
+    const nextActivatingItemUids = getActivationUids(currentProfileUid);
     try {
       startActivation(nextActivatingItemUids);
       await enhanceProfiles();
@@ -175,38 +176,34 @@ const ProfilePage = () => {
     }
   });
 
-  const handleProfileDragEnd = useLockFn(
-    async (event: DragEndEvent) => {
-      setDraggingItem(null);
-      const { active, over } = event;
-      if (!over || active.id === over.id) return;
+  const handleProfileDragEnd = useLockFn(async (event: DragEndEvent) => {
+    setDraggingItem(null);
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
 
-      const activeId = active.id.toString();
-      const overId = over.id.toString();
-      await reorderProfile(activeId, overId);
-    },
-  );
+    const activeId = active.id.toString();
+    const overId = over.id.toString();
+    await reorderProfile(activeId, overId);
+  });
 
-  const handleChainDragEnd = useLockFn(
-    async (event: DragEndEvent) => {
-      setDraggingItem(null);
-      const { active, over } = event;
-      if (!over || active.id === over.id) return;
+  const handleChainDragEnd = useLockFn(async (event: DragEndEvent) => {
+    setDraggingItem(null);
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
 
-      const activeId = active.id.toString();
-      const overId = over.id.toString();
-      const newChainList = reorderItems(globalChainItems, activeId, overId);
-      const needToEnhance = !isEqual(
-        enabledGlobalChainUids,
-        getEnabledUids(newChainList),
-      );
+    const activeId = active.id.toString();
+    const overId = over.id.toString();
+    const newChainList = reorderItems(globalChainItems, activeId, overId);
+    const needToEnhance = !isEqual(
+      enabledGlobalChainUids,
+      getEnabledUids(newChainList),
+    );
 
-      await reorderProfile(activeId, overId);
-      if (needToEnhance) {
-        await onEnhance();
-      }
-    },
-  );
+    await reorderProfile(activeId, overId);
+    if (needToEnhance) {
+      await onEnhance();
+    }
+  });
 
   const onImport = useCallback(async () => {
     if (!url) return;
@@ -230,7 +227,7 @@ const ProfilePage = () => {
   }, [importProfile, notice, patchConfig, t, url]);
 
   const onSelect = useLockFn(async (current: string) => {
-    if (current === config.current || hasActivatingItems) return;
+    if (current === currentProfileUid || hasActivatingItems) return;
     const nextActivatingItemUids = getActivationUids(current);
     try {
       startActivation(nextActivatingItemUids);
@@ -245,8 +242,8 @@ const ProfilePage = () => {
 
   const onDelete = useLockFn(async (uid: string) => {
     const isEnable =
-      config.current === uid || enabledGlobalChainUids.includes(uid);
-    const nextActivatingItemUids = getActivationUids(config.current, uid);
+      currentProfileUid === uid || enabledGlobalChainUids.includes(uid);
+    const nextActivatingItemUids = getActivationUids(currentProfileUid, uid);
     try {
       if (isEnable) {
         startActivation(nextActivatingItemUids);
@@ -264,7 +261,7 @@ const ProfilePage = () => {
   const handleToggleEnable = useLockFn(
     async (chainUid: string, enable: boolean) => {
       const nextActivatingItemUids = getActivationUids(
-        config.current,
+        currentProfileUid,
         chainUid,
       );
       try {
@@ -280,7 +277,10 @@ const ProfilePage = () => {
   );
 
   const handleChainDelete = useLockFn(async (item: IProfileItem) => {
-    const nextActivatingItemUids = getActivationUids(config.current, item.uid);
+    const nextActivatingItemUids = getActivationUids(
+      currentProfileUid,
+      item.uid,
+    );
     try {
       if (item.enable) {
         startActivation(nextActivatingItemUids);
@@ -450,7 +450,7 @@ const ProfilePage = () => {
                     <ProfileItem
                       selected={
                         activatingUidSet.has(item.uid) ||
-                        (!hasActivatingItems && config.current === item.uid)
+                        (!hasActivatingItems && currentProfileUid === item.uid)
                       }
                       isDragging={draggingItem?.uid === item.uid}
                       activating={activatingUidSet.has(item.uid)}
@@ -476,7 +476,8 @@ const ProfilePage = () => {
                 }}
                 selected={
                   activatingUidSet.has(draggingItem.uid) ||
-                  (!hasActivatingItems && config.current === draggingItem.uid)
+                  (!hasActivatingItems &&
+                    currentProfileUid === draggingItem.uid)
                 }
                 activating={activatingUidSet.has(draggingItem.uid)}
                 itemData={draggingItem}

--- a/src/stores/profilesStore.ts
+++ b/src/stores/profilesStore.ts
@@ -40,16 +40,7 @@ type ProfilesPersistedState = Pick<
   | "chainItemsByProfileUid"
 >;
 
-type ProfilesSnapshot = Pick<
-  ProfilesState,
-  | "currentProfile"
-  | "profileItems"
-  | "globalChainItems"
-  | "chainItemsByProfileUid"
->;
-
 type ProfilesActions = {
-  setConfig: (config: IProfilesConfig) => void;
   refreshConfig: () => Promise<IProfilesConfig>;
   patchConfig: (value: Partial<IProfilesConfig>) => Promise<void>;
   patchCurrentProfile: (value: Partial<IProfileItem>) => Promise<void>;
@@ -126,7 +117,9 @@ const pickProfilesState = (state: ProfilesState): ProfilesDerivedState => ({
   globalChainItems: state.globalChainItems,
 });
 
-const pickProfilesSnapshot = (state: ProfilesState): ProfilesSnapshot => ({
+const pickProfilesSnapshot = (
+  state: ProfilesStore,
+): ProfilesPersistedState => ({
   ...pickProfilesState(state),
   chainItemsByProfileUid: state.chainItemsByProfileUid,
 });
@@ -204,10 +197,6 @@ export const useProfilesStore = create<ProfilesStore>()(
       chainItemsByProfileUid: {},
       chainLogs: {},
       activatingItemUids: [],
-
-      setConfig: (config) => {
-        commitConfig(set, get, config);
-      },
 
       refreshConfig: async () => {
         const config = await getProfiles();
@@ -332,12 +321,7 @@ export const useProfilesStore = create<ProfilesStore>()(
     }),
     {
       name: "profiles-store",
-      partialize: (state): ProfilesPersistedState => ({
-        currentProfile: state.currentProfile,
-        profileItems: state.profileItems,
-        globalChainItems: state.globalChainItems,
-        chainItemsByProfileUid: state.chainItemsByProfileUid,
-      }),
+      partialize: pickProfilesSnapshot,
     },
   ),
 );

--- a/src/stores/profilesStore.ts
+++ b/src/stores/profilesStore.ts
@@ -18,11 +18,9 @@ import {
 } from "@/services/cmds";
 
 type ProfilesState = {
-  config: IProfilesConfig;
   currentProfile?: IProfileItem;
   profileItems: IProfileItem[];
   globalChainItems: IProfileItem[];
-  enabledGlobalChainUids: string[];
   chainItemsByProfileUid: Record<string, IProfileItem[]>;
   chainLogs: Record<string, LogMessage[]>;
   // 切换订阅时, 使用中的订阅的激活状态
@@ -31,30 +29,22 @@ type ProfilesState = {
 
 type ProfilesDerivedState = Pick<
   ProfilesState,
-  | "config"
-  | "currentProfile"
-  | "profileItems"
-  | "globalChainItems"
-  | "enabledGlobalChainUids"
+  "currentProfile" | "profileItems" | "globalChainItems"
 >;
 
 type ProfilesPersistedState = Pick<
   ProfilesState,
-  | "config"
   | "currentProfile"
   | "profileItems"
   | "globalChainItems"
-  | "enabledGlobalChainUids"
   | "chainItemsByProfileUid"
 >;
 
 type ProfilesSnapshot = Pick<
   ProfilesState,
-  | "config"
   | "currentProfile"
   | "profileItems"
   | "globalChainItems"
-  | "enabledGlobalChainUids"
   | "chainItemsByProfileUid"
 >;
 
@@ -94,7 +84,9 @@ const isChainType = (type?: IProfileItem["type"]) =>
 
 const isEnabledChainUid = (state: ProfilesState, uid?: string) => {
   if (!uid) return false;
-  if (state.enabledGlobalChainUids.includes(uid)) return true;
+  if (state.globalChainItems.some((item) => item.uid === uid && item.enable)) {
+    return true;
+  }
   return Object.values(state.chainItemsByProfileUid).some((items) =>
     items.some((item) => item.uid === uid && item.enable),
   );
@@ -107,7 +99,7 @@ const shouldRefreshChainLogs = (
 ) => {
   if (!uid) return false;
   return (
-    uid === state.config.current ||
+    uid === state.currentProfile?.uid ||
     isEnabledChainUid(state, uid) ||
     profile?.enable === true
   );
@@ -122,22 +114,16 @@ const toProfileView = (config: IProfilesConfig = {}): ProfilesDerivedState => {
   );
 
   return {
-    config,
     currentProfile: items.find((item) => item.uid === config.current),
     profileItems: items.filter((item) => isProfileType(item.type)),
     globalChainItems,
-    enabledGlobalChainUids: globalChainItems
-      .filter((item) => item.enable)
-      .map((item) => item.uid),
   };
 };
 
 const pickProfilesState = (state: ProfilesState): ProfilesDerivedState => ({
-  config: state.config,
   currentProfile: state.currentProfile,
   profileItems: state.profileItems,
   globalChainItems: state.globalChainItems,
-  enabledGlobalChainUids: state.enabledGlobalChainUids,
 });
 
 const pickProfilesSnapshot = (state: ProfilesState): ProfilesSnapshot => ({
@@ -174,20 +160,6 @@ const reorderItems = <T extends { uid: string }>(
   return nextItems;
 };
 
-const reorderConfig = (
-  config: IProfilesConfig,
-  activeId: string,
-  overId: string,
-) => {
-  const items = (config.items ?? []).filter(
-    (item): item is IProfileItem => !!item,
-  );
-  return {
-    ...config,
-    items: reorderItems(items, activeId, overId),
-  };
-};
-
 const reorderChainCache = (
   cache: Record<string, IProfileItem[]>,
   activeId: string,
@@ -209,17 +181,16 @@ const commitReorder = (
   activeId: string,
   overId: string,
 ) => {
-  const nextState = toProfileView(
-    reorderConfig(get().config, activeId, overId),
-  );
+  const state = get();
   const nextChainItemsByProfileUid = reorderChainCache(
-    get().chainItemsByProfileUid,
+    state.chainItemsByProfileUid,
     activeId,
     overId,
   );
 
   set({
-    ...nextState,
+    profileItems: reorderItems(state.profileItems, activeId, overId),
+    globalChainItems: reorderItems(state.globalChainItems, activeId, overId),
     chainItemsByProfileUid: nextChainItemsByProfileUid,
   });
 };
@@ -227,11 +198,9 @@ const commitReorder = (
 export const useProfilesStore = create<ProfilesStore>()(
   persist(
     (set, get) => ({
-      config: {},
       currentProfile: undefined,
       profileItems: [],
       globalChainItems: [],
-      enabledGlobalChainUids: [],
       chainItemsByProfileUid: {},
       chainLogs: {},
       activatingItemUids: [],
@@ -247,7 +216,8 @@ export const useProfilesStore = create<ProfilesStore>()(
 
       patchConfig: async (value) => {
         const shouldRefreshLogs =
-          (value.current != null && value.current !== get().config.current) ||
+          (value.current != null &&
+            value.current !== get().currentProfile?.uid) ||
           value.chain != null;
         await patchProfilesConfig(value);
         await get().refreshConfig();
@@ -257,7 +227,7 @@ export const useProfilesStore = create<ProfilesStore>()(
       },
 
       patchCurrentProfile: async (value) => {
-        const current = get().config.current;
+        const current = get().currentProfile?.uid;
         if (!current) return;
         await get().patchProfile(current, value);
       },
@@ -363,11 +333,9 @@ export const useProfilesStore = create<ProfilesStore>()(
     {
       name: "profiles-store",
       partialize: (state): ProfilesPersistedState => ({
-        config: state.config,
         currentProfile: state.currentProfile,
         profileItems: state.profileItems,
         globalChainItems: state.globalChainItems,
-        enabledGlobalChainUids: state.enabledGlobalChainUids,
         chainItemsByProfileUid: state.chainItemsByProfileUid,
       }),
     },


### PR DESCRIPTION
## 变更概述
- 精简 profiles store 的持久化状态，移除重复保存的 `config`、`currentProfileUid` 和 `enabledGlobalChainUids`
- 统一从 `currentProfile`、`globalChainItems` 和 profile chain 缓存派生当前订阅与启用链状态
- 移除 profiles store 内部临时 `profilesConfig` 缓存，订阅拖拽乐观更新直接基于当前 store 列表重排
- 删除未使用的 `setConfig` action，并复用持久化字段选择逻辑，减少重复代码
- 更新 profiles 页与 proxy 相关组件，改为读取派生后的当前订阅信息

## 影响范围
- profiles store 状态结构与持久化字段
- profiles 页面订阅选中、删除、启用链和重排相关逻辑
- proxy head/render/render-list 中按当前订阅隔离的 UI 状态读取

## 验证情况
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint src/stores/profilesStore.ts src/pages/profiles.tsx src/components/proxy/proxy-head.tsx src/components/proxy/proxy-render.tsx src/components/proxy/use-render-list.ts --max-warnings=0`
- `git diff --check`
- GitNexus detect_changes compare `origin/dev...HEAD`: risk medium, affected process `UseRenderList → HashKey`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactoring**
  * Active profile selection and state tracking made more reliable across the UI.
  * Profile dragging now only reorders profiles; chain dragging still triggers enhancements when enabled items change.
  * Global chain enablement and profile-related persistence simplified to reduce inconsistent selections, enables, and refresh behavior.
* **Bug Fixes**
  * Improved initialization sequence to ensure theme and editor assets load after profile and chain data are refreshed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->