### PR TITLE
perf(proxy): cache proxy group icons

### DIFF
--- a/src/components/proxy/proxy-render.tsx
+++ b/src/components/proxy/proxy-render.tsx
@@ -75,8 +75,17 @@ const GROUP_ICON_STYLE = { marginRight: "12px", borderRadius: "6px" };
 const groupIconSrcCache = new Map<string, string>();
 const groupIconLoadingCache = new Map<string, Promise<string>>();
 
-const getGroupIconCacheKey = (groupName: string, groupIcon: string) =>
-  `${groupName}::${groupIcon}`;
+const getIconPathCacheKey = (url: string) => {
+  try {
+    const iconUrl = new URL(url);
+    return `${iconUrl.origin}${iconUrl.pathname}`;
+  } catch {
+    return url.split(/[?#]/, 1)[0];
+  }
+};
+
+const getGroupIconCacheKey = (groupIcon: string) =>
+  getIconPathCacheKey(groupIcon);
 
 const getFileName = (url: string) => {
   try {
@@ -87,7 +96,20 @@ const getFileName = (url: string) => {
     // fallback for non-standard URL strings
   }
 
-  return url.substring(url.lastIndexOf("/") + 1);
+  const cacheKey = getIconPathCacheKey(url);
+  return cacheKey.substring(cacheKey.lastIndexOf("/") + 1);
+};
+
+const splitFileName = (fileName: string) => {
+  const extensionIndex = fileName.lastIndexOf(".");
+  if (extensionIndex <= 0 || extensionIndex === fileName.length - 1) {
+    return { stem: fileName, extension: ".png" };
+  }
+
+  return {
+    stem: fileName.slice(0, extensionIndex),
+    extension: fileName.slice(extensionIndex),
+  };
 };
 
 const sanitizeFileName = (fileName: string) =>
@@ -97,6 +119,13 @@ const sanitizeFileName = (fileName: string) =>
     .replace(/-+/g, "-")
     .replace(/^[.\-\s]+|[.\-\s]+$/g, "")
     .slice(0, 80) || "icon";
+
+const sanitizeExtension = (extension: string) => {
+  const safeExtension = extension.replace(/[^a-zA-Z0-9.]/g, "").slice(0, 16);
+  return safeExtension.startsWith(".") && safeExtension.length > 1
+    ? safeExtension
+    : ".png";
+};
 
 const sha256Hex = async (value: string) => {
   const digest = await crypto.subtle.digest(
@@ -109,17 +138,23 @@ const sha256Hex = async (value: string) => {
     .join("");
 };
 
-const getGroupIconSrc = async (groupName: string, groupIcon: string) => {
-  const cacheKey = getGroupIconCacheKey(groupName, groupIcon);
+const getIconCacheFileName = async (groupIcon: string) => {
+  const { stem, extension } = splitFileName(getFileName(groupIcon));
+  const cacheKey = getIconPathCacheKey(groupIcon);
+  return `${sanitizeFileName(stem)}-${await sha256Hex(cacheKey)}${sanitizeExtension(
+    extension,
+  )}`;
+};
+
+const getGroupIconSrc = async (groupIcon: string) => {
+  const cacheKey = getGroupIconCacheKey(groupIcon);
   const cachedSrc = groupIconSrcCache.get(cacheKey);
   if (cachedSrc) return cachedSrc;
 
   const loadingSrc = groupIconLoadingCache.get(cacheKey);
   if (loadingSrc) return loadingSrc;
 
-  const fileName = `${sanitizeFileName(getFileName(groupIcon))}-${await sha256Hex(
-    groupIcon,
-  )}`;
+  const fileName = await getIconCacheFileName(groupIcon);
   const loadIcon = downloadIconCache(groupIcon, fileName)
     .then((iconPath) => {
       const iconSrc = convertFileSrc(iconPath);
@@ -186,8 +221,7 @@ export const ProxyRender = memo(function ProxyRender(props: RenderProps) {
   const isInlineSvgIcon = groupIcon.startsWith("<svg");
   const [iconCachePath, setIconCachePath] = useState(() =>
     isHttpIcon
-      ? (groupIconSrcCache.get(getGroupIconCacheKey(group.name, groupIcon)) ??
-        "")
+      ? (groupIconSrcCache.get(getGroupIconCacheKey(groupIcon)) ?? "")
       : "",
   );
 
@@ -197,7 +231,7 @@ export const ProxyRender = memo(function ProxyRender(props: RenderProps) {
       return;
     }
 
-    const cacheKey = getGroupIconCacheKey(group.name, groupIcon);
+    const cacheKey = getGroupIconCacheKey(groupIcon);
     const cachedSrc = groupIconSrcCache.get(cacheKey);
     if (cachedSrc) {
       setIconCachePath(cachedSrc);
@@ -206,7 +240,7 @@ export const ProxyRender = memo(function ProxyRender(props: RenderProps) {
 
     let canceled = false;
     setIconCachePath("");
-    getGroupIconSrc(group.name, groupIcon)
+    getGroupIconSrc(groupIcon)
       .then((iconSrc) => {
         if (!canceled) {
           setIconCachePath(iconSrc);

--- a/src/components/proxy/proxy-render.tsx
+++ b/src/components/proxy/proxy-render.tsx
@@ -75,7 +75,6 @@ const StyledTypeBox = styled(ListItemTextChild)(({ theme }) => ({
 const GROUP_ICON_STYLE = { marginRight: "12px", borderRadius: "6px" };
 const ICON_FILE_NAME_MAX_LENGTH = 32;
 const ICON_HASH_LENGTH = 16;
-const groupIconMetaCache = new Map<string, Promise<{ fileName: string }>>();
 const groupIconSrcCache = new Map<string, string>();
 const groupIconLoadingCache = new Map<string, Promise<string>>();
 
@@ -139,22 +138,18 @@ const sha256Hex = async (value: string) => {
     .join("");
 };
 
-const getGroupIconMeta = (groupIcon: string) => {
-  const normalizedUrl = normalizeIconUrl(groupIcon);
-  const cachedMeta = groupIconMetaCache.get(normalizedUrl);
-  if (cachedMeta) return cachedMeta;
+const getIconCacheFileName = async (groupIcon: string, cacheKey: string) => {
+  const hashName = (await sha256Hex(cacheKey)).slice(0, ICON_HASH_LENGTH);
+  const { stem, extension } = getIconFileParts(getIconFileName(groupIcon));
+  return `${sanitizeFileName(stem)}-${hashName}${sanitizeExtension(extension)}`;
+};
 
-  const meta = sha256Hex(normalizedUrl).then((hash) => {
-    const hashName = hash.slice(0, ICON_HASH_LENGTH);
-    const { stem, extension } = getIconFileParts(getIconFileName(groupIcon));
-    const fileName = `${sanitizeFileName(stem)}-${hashName}${sanitizeExtension(
-      extension,
-    )}`;
-    return { fileName };
-  });
-
-  groupIconMetaCache.set(normalizedUrl, meta);
-  return meta;
+const loadGroupIconSrc = async (groupIcon: string, cacheKey: string) => {
+  const fileName = await getIconCacheFileName(groupIcon, cacheKey);
+  const iconPath = await downloadIconCache(groupIcon, fileName);
+  const iconSrc = convertFileSrc(iconPath);
+  groupIconSrcCache.set(cacheKey, iconSrc);
+  return iconSrc;
 };
 
 const getGroupIconSrc = async (groupIcon: string) => {
@@ -165,13 +160,7 @@ const getGroupIconSrc = async (groupIcon: string) => {
   const loadingSrc = groupIconLoadingCache.get(cacheKey);
   if (loadingSrc) return await loadingSrc;
 
-  const loadIcon = (async () => {
-    const { fileName } = await getGroupIconMeta(groupIcon);
-    const iconPath = await downloadIconCache(groupIcon, fileName);
-    const iconSrc = convertFileSrc(iconPath);
-    groupIconSrcCache.set(cacheKey, iconSrc);
-    return iconSrc;
-  })().finally(() => {
+  const loadIcon = loadGroupIconSrc(groupIcon, cacheKey).finally(() => {
     groupIconLoadingCache.delete(cacheKey);
   });
 

--- a/src/components/proxy/proxy-render.tsx
+++ b/src/components/proxy/proxy-render.tsx
@@ -78,7 +78,36 @@ const groupIconLoadingCache = new Map<string, Promise<string>>();
 const getGroupIconCacheKey = (groupName: string, groupIcon: string) =>
   `${groupName}::${groupIcon}`;
 
-const getFileName = (url: string) => url.substring(url.lastIndexOf("/") + 1);
+const getFileName = (url: string) => {
+  try {
+    const pathname = new URL(url).pathname;
+    const fileName = pathname.substring(pathname.lastIndexOf("/") + 1);
+    if (fileName) return decodeURIComponent(fileName);
+  } catch {
+    // fallback for non-standard URL strings
+  }
+
+  return url.substring(url.lastIndexOf("/") + 1);
+};
+
+const sanitizeFileName = (fileName: string) =>
+  fileName
+    .replace(/[<>:"/\\|?*\u0000-\u001F]/g, "-")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[.\-\s]+|[.\-\s]+$/g, "")
+    .slice(0, 80) || "icon";
+
+const sha256Hex = async (value: string) => {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value),
+  );
+
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+};
 
 const getGroupIconSrc = async (groupName: string, groupIcon: string) => {
   const cacheKey = getGroupIconCacheKey(groupName, groupIcon);
@@ -88,7 +117,9 @@ const getGroupIconSrc = async (groupName: string, groupIcon: string) => {
   const loadingSrc = groupIconLoadingCache.get(cacheKey);
   if (loadingSrc) return loadingSrc;
 
-  const fileName = groupName.replaceAll(" ", "") + "-" + getFileName(groupIcon);
+  const fileName = `${sanitizeFileName(getFileName(groupIcon))}-${await sha256Hex(
+    groupIcon,
+  )}`;
   const loadIcon = downloadIconCache(groupIcon, fileName)
     .then((iconPath) => {
       const iconSrc = convertFileSrc(iconPath);

--- a/src/components/proxy/proxy-render.tsx
+++ b/src/components/proxy/proxy-render.tsx
@@ -156,28 +156,28 @@ const getIconCacheFileName = (groupIcon: string, cacheKey: string) => {
   return `${sanitizeFileName(stem)}-${cacheKey}${sanitizeExtension(extension)}`;
 };
 
+const loadGroupIconSrc = async (groupIcon: string, cacheKey: string) => {
+  const fileName = getIconCacheFileName(groupIcon, cacheKey);
+  const iconPath = await downloadIconCache(groupIcon, fileName);
+  const iconSrc = convertFileSrc(iconPath);
+  groupIconSrcCache.set(cacheKey, iconSrc);
+  return iconSrc;
+};
+
 const getGroupIconSrc = async (groupIcon: string) => {
-  return getGroupIconCacheKey(groupIcon).then((cacheKey) => {
-    const cachedSrc = groupIconSrcCache.get(cacheKey);
-    if (cachedSrc) return cachedSrc;
+  const cacheKey = await getGroupIconCacheKey(groupIcon);
+  const cachedSrc = groupIconSrcCache.get(cacheKey);
+  if (cachedSrc) return cachedSrc;
 
-    const loadingSrc = groupIconLoadingCache.get(cacheKey);
-    if (loadingSrc) return loadingSrc;
+  const loadingSrc = groupIconLoadingCache.get(cacheKey);
+  if (loadingSrc) return await loadingSrc;
 
-    const fileName = getIconCacheFileName(groupIcon, cacheKey);
-    const loadIcon = downloadIconCache(groupIcon, fileName)
-      .then((iconPath) => {
-        const iconSrc = convertFileSrc(iconPath);
-        groupIconSrcCache.set(cacheKey, iconSrc);
-        return iconSrc;
-      })
-      .finally(() => {
-        groupIconLoadingCache.delete(cacheKey);
-      });
-
-    groupIconLoadingCache.set(cacheKey, loadIcon);
-    return loadIcon;
+  const loadIcon = loadGroupIconSrc(groupIcon, cacheKey).finally(() => {
+    groupIconLoadingCache.delete(cacheKey);
   });
+
+  groupIconLoadingCache.set(cacheKey, loadIcon);
+  return await loadIcon;
 };
 
 const ProxyItemMiniCol = memo(function ProxyItemMiniCol(props: ProxyColProps) {

--- a/src/components/proxy/proxy-render.tsx
+++ b/src/components/proxy/proxy-render.tsx
@@ -283,22 +283,26 @@ export const ProxyRender = memo(function ProxyRender(props: RenderProps) {
           transition: "background-color 0s",
         })}
         onClick={() => headStateActions.setOpen(!headState?.open)}>
-        {enableGroupIcon && isHttpIcon && iconCachePath && (
-          <img src={iconCachePath} width="32px" style={GROUP_ICON_STYLE} />
-        )}
-        {enableGroupIcon && isHttpIcon && !iconCachePath && iconLoading && (
-          <Box sx={GROUP_ICON_LOADING_STYLE}>
-            <CircularProgress size={18} />
-          </Box>
-        )}
-        {enableGroupIcon && isDataIcon && (
-          <img src={groupIcon} width="32px" style={GROUP_ICON_STYLE} />
-        )}
-        {enableGroupIcon && isInlineSvgIcon && (
-          <img
-            src={`data:image/svg+xml;base64,${btoa(groupIcon)}`}
-            width="32px"
-          />
+        {enableGroupIcon && (
+          <>
+            {isHttpIcon && !iconCachePath && iconLoading && (
+              <Box sx={GROUP_ICON_LOADING_STYLE}>
+                <CircularProgress size={18} />
+              </Box>
+            )}
+            {isHttpIcon && iconCachePath && (
+              <img src={iconCachePath} width="32px" style={GROUP_ICON_STYLE} />
+            )}
+            {isDataIcon && (
+              <img src={groupIcon} width="32px" style={GROUP_ICON_STYLE} />
+            )}
+            {isInlineSvgIcon && (
+              <img
+                src={`data:image/svg+xml;base64,${btoa(groupIcon)}`}
+                width="32px"
+              />
+            )}
+          </>
         )}
         <ListItemText
           primary={<StyledPrimary>{group.name}</StyledPrimary>}

--- a/src/components/proxy/proxy-render.tsx
+++ b/src/components/proxy/proxy-render.tsx
@@ -77,17 +77,17 @@ const ICON_HASH_LENGTH = 16;
 const groupIconSrcCache = new Map<string, string>();
 const groupIconLoadingCache = new Map<string, Promise<string>>();
 
-const getIconPathCacheKey = (url: string) => {
+const getIconUrlCacheKey = (url: string) => {
   try {
     const iconUrl = new URL(url);
-    return `${iconUrl.origin}${iconUrl.pathname}`;
+    return `${iconUrl.origin}${iconUrl.pathname}${iconUrl.search}${iconUrl.hash}`;
   } catch {
-    return url.split(/[?#]/, 1)[0];
+    return url;
   }
 };
 
 const getGroupIconCacheKey = (groupIcon: string) =>
-  getIconPathCacheKey(groupIcon);
+  getIconUrlCacheKey(groupIcon);
 
 const getFileName = (url: string) => {
   try {
@@ -98,8 +98,8 @@ const getFileName = (url: string) => {
     // fallback for non-standard URL strings
   }
 
-  const cacheKey = getIconPathCacheKey(url);
-  return cacheKey.substring(cacheKey.lastIndexOf("/") + 1);
+  const path = url.split(/[?#]/, 1)[0];
+  return path.substring(path.lastIndexOf("/") + 1);
 };
 
 const splitFileName = (fileName: string) => {
@@ -142,7 +142,7 @@ const sha256Hex = async (value: string) => {
 
 const getIconCacheFileName = async (groupIcon: string) => {
   const { stem, extension } = splitFileName(getFileName(groupIcon));
-  const cacheKey = getIconPathCacheKey(groupIcon);
+  const cacheKey = getIconUrlCacheKey(groupIcon);
   const hash = (await sha256Hex(cacheKey)).slice(0, ICON_HASH_LENGTH);
   return `${sanitizeFileName(stem)}-${hash}${sanitizeExtension(extension)}`;
 };

--- a/src/components/proxy/proxy-render.tsx
+++ b/src/components/proxy/proxy-render.tsx
@@ -227,17 +227,18 @@ export const ProxyRender = memo(function ProxyRender(props: RenderProps) {
   const isHttpIcon = groupIcon.startsWith("http");
   const isDataIcon = groupIcon.startsWith("data");
   const isInlineSvgIcon = groupIcon.startsWith("<svg");
-  const iconCacheKey = isHttpIcon ? normalizeIconUrl(groupIcon) : "";
+  const shouldLoadHttpIcon = enableGroupIcon && isHttpIcon;
+  const iconCacheKey = shouldLoadHttpIcon ? normalizeIconUrl(groupIcon) : "";
   const [iconCachePath, setIconCachePath] = useState(
     () => groupIconSrcCache.get(iconCacheKey) ?? "",
   );
   const [iconLoading, setIconLoading] = useState(
-    () => isHttpIcon && !groupIconSrcCache.has(iconCacheKey),
+    () => shouldLoadHttpIcon && !groupIconSrcCache.has(iconCacheKey),
   );
 
   useAsyncEffect(
     async function* () {
-      if (!isHttpIcon) {
+      if (!shouldLoadHttpIcon) {
         setIconCachePath("");
         setIconLoading(false);
         return;
@@ -264,7 +265,7 @@ export const ProxyRender = memo(function ProxyRender(props: RenderProps) {
         setIconLoading(false);
       }
     },
-    [isHttpIcon, groupIcon, iconCacheKey],
+    [shouldLoadHttpIcon, groupIcon, iconCacheKey],
   );
 
   if (type === 0) {

--- a/src/components/proxy/proxy-render.tsx
+++ b/src/components/proxy/proxy-render.tsx
@@ -72,6 +72,8 @@ const StyledTypeBox = styled(ListItemTextChild)(({ theme }) => ({
 }));
 
 const GROUP_ICON_STYLE = { marginRight: "12px", borderRadius: "6px" };
+const ICON_FILE_NAME_MAX_LENGTH = 32;
+const ICON_HASH_LENGTH = 16;
 const groupIconSrcCache = new Map<string, string>();
 const groupIconLoadingCache = new Map<string, Promise<string>>();
 
@@ -118,7 +120,7 @@ const sanitizeFileName = (fileName: string) =>
     .replace(/\s+/g, "-")
     .replace(/-+/g, "-")
     .replace(/^[.\-\s]+|[.\-\s]+$/g, "")
-    .slice(0, 80) || "icon";
+    .slice(0, ICON_FILE_NAME_MAX_LENGTH) || "icon";
 
 const sanitizeExtension = (extension: string) => {
   const safeExtension = extension.replace(/[^a-zA-Z0-9.]/g, "").slice(0, 16);
@@ -141,9 +143,8 @@ const sha256Hex = async (value: string) => {
 const getIconCacheFileName = async (groupIcon: string) => {
   const { stem, extension } = splitFileName(getFileName(groupIcon));
   const cacheKey = getIconPathCacheKey(groupIcon);
-  return `${sanitizeFileName(stem)}-${await sha256Hex(cacheKey)}${sanitizeExtension(
-    extension,
-  )}`;
+  const hash = (await sha256Hex(cacheKey)).slice(0, ICON_HASH_LENGTH);
+  return `${sanitizeFileName(stem)}-${hash}${sanitizeExtension(extension)}`;
 };
 
 const getGroupIconSrc = async (groupIcon: string) => {

--- a/src/components/proxy/proxy-render.tsx
+++ b/src/components/proxy/proxy-render.tsx
@@ -234,7 +234,7 @@ export const ProxyRender = memo(function ProxyRender(props: RenderProps) {
   const [iconCachePath, setIconCachePath] = useState("");
 
   useAsyncEffect(
-    async function* () {
+    async function () {
       if (!isHttpIcon) {
         setIconCachePath("");
         return;
@@ -244,10 +244,8 @@ export const ProxyRender = memo(function ProxyRender(props: RenderProps) {
 
       try {
         const iconSrc = await getGroupIconSrc(groupIcon);
-        yield;
         setIconCachePath(iconSrc);
       } catch {
-        yield;
         setIconCachePath("");
       }
     },

--- a/src/components/proxy/proxy-render.tsx
+++ b/src/components/proxy/proxy-render.tsx
@@ -136,6 +136,9 @@ const sanitizeExtension = (extension: string) => {
     : ".png";
 };
 
+const encodeSvgDataUri = (svg: string) =>
+  `data:image/svg+xml,${encodeURIComponent(svg)}`;
+
 const sha256Hex = async (value: string) => {
   const digest = await crypto.subtle.digest(
     "SHA-256",
@@ -299,8 +302,9 @@ export const ProxyRender = memo(function ProxyRender(props: RenderProps) {
             )}
             {isInlineSvgIcon && (
               <img
-                src={`data:image/svg+xml;base64,${btoa(groupIcon)}`}
+                src={encodeSvgDataUri(groupIcon)}
                 width="32px"
+                style={GROUP_ICON_STYLE}
               />
             )}
           </>

--- a/src/components/proxy/proxy-render.tsx
+++ b/src/components/proxy/proxy-render.tsx
@@ -10,7 +10,6 @@ import {
   Typography,
 } from "@mui/material";
 import { convertFileSrc } from "@tauri-apps/api/core";
-import { useMemoizedFn } from "ahooks";
 import { memo, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -72,6 +71,38 @@ const StyledTypeBox = styled(ListItemTextChild)(({ theme }) => ({
   marginRight: "8px",
 }));
 
+const GROUP_ICON_STYLE = { marginRight: "12px", borderRadius: "6px" };
+const groupIconSrcCache = new Map<string, string>();
+const groupIconLoadingCache = new Map<string, Promise<string>>();
+
+const getGroupIconCacheKey = (groupName: string, groupIcon: string) =>
+  `${groupName}::${groupIcon}`;
+
+const getFileName = (url: string) => url.substring(url.lastIndexOf("/") + 1);
+
+const getGroupIconSrc = async (groupName: string, groupIcon: string) => {
+  const cacheKey = getGroupIconCacheKey(groupName, groupIcon);
+  const cachedSrc = groupIconSrcCache.get(cacheKey);
+  if (cachedSrc) return cachedSrc;
+
+  const loadingSrc = groupIconLoadingCache.get(cacheKey);
+  if (loadingSrc) return loadingSrc;
+
+  const fileName = groupName.replaceAll(" ", "") + "-" + getFileName(groupIcon);
+  const loadIcon = downloadIconCache(groupIcon, fileName)
+    .then((iconPath) => {
+      const iconSrc = convertFileSrc(iconPath);
+      groupIconSrcCache.set(cacheKey, iconSrc);
+      return iconSrc;
+    })
+    .finally(() => {
+      groupIconLoadingCache.delete(cacheKey);
+    });
+
+  groupIconLoadingCache.set(cacheKey, loadIcon);
+  return loadIcon;
+};
+
 const ProxyItemMiniCol = memo(function ProxyItemMiniCol(props: ProxyColProps) {
   const { item, delayVersion, onChangeProxy } = props;
   const { group, headState, proxyCol } = item;
@@ -118,34 +149,48 @@ export const ProxyRender = memo(function ProxyRender(props: RenderProps) {
       }),
     [currentProfileUid, group.name],
   );
-  const [iconCachePath, setIconCachePath] = useState("");
   const groupIcon = group.icon?.trim() ?? "";
   const isHttpIcon = groupIcon.startsWith("http");
   const isDataIcon = groupIcon.startsWith("data");
   const isInlineSvgIcon = groupIcon.startsWith("<svg");
-
-  const initIconCachePath = useMemoizedFn(
-    async (groupName: string, groupIcon: string) => {
-      if (isHttpIcon) {
-        const fileName =
-          groupName.replaceAll(" ", "") + "-" + getFileName(groupIcon);
-        const iconPath = await downloadIconCache(groupIcon, fileName);
-        setIconCachePath(convertFileSrc(iconPath));
-      }
-    },
+  const [iconCachePath, setIconCachePath] = useState(() =>
+    isHttpIcon
+      ? (groupIconSrcCache.get(getGroupIconCacheKey(group.name, groupIcon)) ??
+        "")
+      : "",
   );
-
-  const getFileName = useMemoizedFn((url: string) => {
-    return url.substring(url.lastIndexOf("/") + 1);
-  });
 
   useEffect(() => {
     if (!isHttpIcon) {
       setIconCachePath("");
       return;
     }
-    initIconCachePath(group.name, groupIcon);
-  }, [initIconCachePath, isHttpIcon, group.name, groupIcon]);
+
+    const cacheKey = getGroupIconCacheKey(group.name, groupIcon);
+    const cachedSrc = groupIconSrcCache.get(cacheKey);
+    if (cachedSrc) {
+      setIconCachePath(cachedSrc);
+      return;
+    }
+
+    let canceled = false;
+    setIconCachePath("");
+    getGroupIconSrc(group.name, groupIcon)
+      .then((iconSrc) => {
+        if (!canceled) {
+          setIconCachePath(iconSrc);
+        }
+      })
+      .catch(() => {
+        if (!canceled) {
+          setIconCachePath("");
+        }
+      });
+
+    return () => {
+      canceled = true;
+    };
+  }, [isHttpIcon, group.name, groupIcon]);
 
   if (type === 0) {
     return (
@@ -163,19 +208,11 @@ export const ProxyRender = memo(function ProxyRender(props: RenderProps) {
           transition: "background-color 0s",
         })}
         onClick={() => headStateActions.setOpen(!headState?.open)}>
-        {enableGroupIcon && isHttpIcon && (
-          <img
-            src={iconCachePath === "" ? groupIcon : iconCachePath}
-            width="32px"
-            style={{ marginRight: "12px", borderRadius: "6px" }}
-          />
+        {enableGroupIcon && isHttpIcon && iconCachePath && (
+          <img src={iconCachePath} width="32px" style={GROUP_ICON_STYLE} />
         )}
         {enableGroupIcon && isDataIcon && (
-          <img
-            src={groupIcon}
-            width="32px"
-            style={{ marginRight: "12px", borderRadius: "6px" }}
-          />
+          <img src={groupIcon} width="32px" style={GROUP_ICON_STYLE} />
         )}
         {enableGroupIcon && isInlineSvgIcon && (
           <img

--- a/src/components/proxy/proxy-render.tsx
+++ b/src/components/proxy/proxy-render.tsx
@@ -4,6 +4,7 @@ import InboxRounded from "@mui/icons-material/InboxRounded";
 import {
   alpha,
   Box,
+  CircularProgress,
   ListItemButton,
   ListItemText,
   styled,
@@ -73,6 +74,14 @@ const StyledTypeBox = styled(ListItemTextChild)(({ theme }) => ({
 }));
 
 const GROUP_ICON_STYLE = { marginRight: "12px", borderRadius: "6px" };
+const GROUP_ICON_LOADING_STYLE = {
+  ...GROUP_ICON_STYLE,
+  width: "32px",
+  height: "32px",
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+};
 const ICON_FILE_NAME_MAX_LENGTH = 32;
 const ICON_HASH_LENGTH = 16;
 const groupIconSrcCache = new Map<string, string>();
@@ -222,29 +231,37 @@ export const ProxyRender = memo(function ProxyRender(props: RenderProps) {
   const [iconCachePath, setIconCachePath] = useState(
     () => groupIconSrcCache.get(iconCacheKey) ?? "",
   );
+  const [iconLoading, setIconLoading] = useState(
+    () => isHttpIcon && !groupIconSrcCache.has(iconCacheKey),
+  );
 
   useAsyncEffect(
     async function* () {
       if (!isHttpIcon) {
         setIconCachePath("");
+        setIconLoading(false);
         return;
       }
 
       const cachedIconSrc = groupIconSrcCache.get(iconCacheKey);
       if (cachedIconSrc) {
         setIconCachePath(cachedIconSrc);
+        setIconLoading(false);
         return;
       }
 
       setIconCachePath("");
+      setIconLoading(true);
 
       try {
         const iconSrc = await getGroupIconSrc(groupIcon);
         yield;
         setIconCachePath(iconSrc);
+        setIconLoading(false);
       } catch {
         yield;
         setIconCachePath("");
+        setIconLoading(false);
       }
     },
     [isHttpIcon, groupIcon, iconCacheKey],
@@ -268,6 +285,11 @@ export const ProxyRender = memo(function ProxyRender(props: RenderProps) {
         onClick={() => headStateActions.setOpen(!headState?.open)}>
         {enableGroupIcon && isHttpIcon && iconCachePath && (
           <img src={iconCachePath} width="32px" style={GROUP_ICON_STYLE} />
+        )}
+        {enableGroupIcon && isHttpIcon && !iconCachePath && iconLoading && (
+          <Box sx={GROUP_ICON_LOADING_STYLE}>
+            <CircularProgress size={18} />
+          </Box>
         )}
         {enableGroupIcon && isDataIcon && (
           <img src={groupIcon} width="32px" style={GROUP_ICON_STYLE} />

--- a/src/components/proxy/proxy-render.tsx
+++ b/src/components/proxy/proxy-render.tsx
@@ -75,10 +75,7 @@ const StyledTypeBox = styled(ListItemTextChild)(({ theme }) => ({
 const GROUP_ICON_STYLE = { marginRight: "12px", borderRadius: "6px" };
 const ICON_FILE_NAME_MAX_LENGTH = 32;
 const ICON_HASH_LENGTH = 16;
-const groupIconMetaCache = new Map<
-  string,
-  Promise<{ cacheKey: string; fileName: string }>
->();
+const groupIconMetaCache = new Map<string, Promise<{ fileName: string }>>();
 const groupIconSrcCache = new Map<string, string>();
 const groupIconLoadingCache = new Map<string, Promise<string>>();
 
@@ -148,12 +145,12 @@ const getGroupIconMeta = (groupIcon: string) => {
   if (cachedMeta) return cachedMeta;
 
   const meta = sha256Hex(normalizedUrl).then((hash) => {
-    const cacheKey = hash.slice(0, ICON_HASH_LENGTH);
+    const hashName = hash.slice(0, ICON_HASH_LENGTH);
     const { stem, extension } = getIconFileParts(getIconFileName(groupIcon));
-    const fileName = `${sanitizeFileName(stem)}-${cacheKey}${sanitizeExtension(
+    const fileName = `${sanitizeFileName(stem)}-${hashName}${sanitizeExtension(
       extension,
     )}`;
-    return { cacheKey, fileName };
+    return { fileName };
   });
 
   groupIconMetaCache.set(normalizedUrl, meta);
@@ -161,7 +158,7 @@ const getGroupIconMeta = (groupIcon: string) => {
 };
 
 const getGroupIconSrc = async (groupIcon: string) => {
-  const { cacheKey, fileName } = await getGroupIconMeta(groupIcon);
+  const cacheKey = normalizeIconUrl(groupIcon);
   const cachedSrc = groupIconSrcCache.get(cacheKey);
   if (cachedSrc) return cachedSrc;
 
@@ -169,6 +166,7 @@ const getGroupIconSrc = async (groupIcon: string) => {
   if (loadingSrc) return await loadingSrc;
 
   const loadIcon = (async () => {
+    const { fileName } = await getGroupIconMeta(groupIcon);
     const iconPath = await downloadIconCache(groupIcon, fileName);
     const iconSrc = convertFileSrc(iconPath);
     groupIconSrcCache.set(cacheKey, iconSrc);
@@ -231,12 +229,21 @@ export const ProxyRender = memo(function ProxyRender(props: RenderProps) {
   const isHttpIcon = groupIcon.startsWith("http");
   const isDataIcon = groupIcon.startsWith("data");
   const isInlineSvgIcon = groupIcon.startsWith("<svg");
-  const [iconCachePath, setIconCachePath] = useState("");
+  const iconCacheKey = isHttpIcon ? normalizeIconUrl(groupIcon) : "";
+  const [iconCachePath, setIconCachePath] = useState(
+    () => groupIconSrcCache.get(iconCacheKey) ?? "",
+  );
 
   useAsyncEffect(
     async function* () {
       if (!isHttpIcon) {
         setIconCachePath("");
+        return;
+      }
+
+      const cachedIconSrc = groupIconSrcCache.get(iconCacheKey);
+      if (cachedIconSrc) {
+        setIconCachePath(cachedIconSrc);
         return;
       }
 
@@ -251,7 +258,7 @@ export const ProxyRender = memo(function ProxyRender(props: RenderProps) {
         setIconCachePath("");
       }
     },
-    [isHttpIcon, groupIcon],
+    [isHttpIcon, groupIcon, iconCacheKey],
   );
 
   if (type === 0) {

--- a/src/components/proxy/proxy-render.tsx
+++ b/src/components/proxy/proxy-render.tsx
@@ -77,7 +77,7 @@ const ICON_HASH_LENGTH = 16;
 const groupIconSrcCache = new Map<string, string>();
 const groupIconLoadingCache = new Map<string, Promise<string>>();
 
-const getIconUrlCacheKey = (url: string) => {
+const getIconUrlCacheValue = (url: string) => {
   try {
     const iconUrl = new URL(url);
     return `${iconUrl.origin}${iconUrl.pathname}${iconUrl.search}${iconUrl.hash}`;
@@ -86,8 +86,25 @@ const getIconUrlCacheKey = (url: string) => {
   }
 };
 
+const hashString = (value: string) => {
+  let hashA = 0x811c9dc5;
+  let hashB = 0x811c9dc5 ^ 0x9e3779b9;
+
+  for (let i = 0; i < value.length; i += 1) {
+    const charCode = value.charCodeAt(i);
+    hashA ^= charCode;
+    hashA = Math.imul(hashA, 0x01000193);
+    hashB ^= charCode;
+    hashB = Math.imul(hashB, 0x85ebca6b);
+  }
+
+  return `${(hashA >>> 0).toString(16).padStart(8, "0")}${(hashB >>> 0)
+    .toString(16)
+    .padStart(8, "0")}`;
+};
+
 const getGroupIconCacheKey = (groupIcon: string) =>
-  getIconUrlCacheKey(groupIcon);
+  hashString(getIconUrlCacheValue(groupIcon));
 
 const getFileName = (url: string) => {
   try {
@@ -142,8 +159,8 @@ const sha256Hex = async (value: string) => {
 
 const getIconCacheFileName = async (groupIcon: string) => {
   const { stem, extension } = splitFileName(getFileName(groupIcon));
-  const cacheKey = getIconUrlCacheKey(groupIcon);
-  const hash = (await sha256Hex(cacheKey)).slice(0, ICON_HASH_LENGTH);
+  const iconUrlCacheValue = getIconUrlCacheValue(groupIcon);
+  const hash = (await sha256Hex(iconUrlCacheValue)).slice(0, ICON_HASH_LENGTH);
   return `${sanitizeFileName(stem)}-${hash}${sanitizeExtension(extension)}`;
 };
 

--- a/src/components/proxy/proxy-render.tsx
+++ b/src/components/proxy/proxy-render.tsx
@@ -74,6 +74,7 @@ const StyledTypeBox = styled(ListItemTextChild)(({ theme }) => ({
 const GROUP_ICON_STYLE = { marginRight: "12px", borderRadius: "6px" };
 const ICON_FILE_NAME_MAX_LENGTH = 32;
 const ICON_HASH_LENGTH = 16;
+const groupIconCacheKeyCache = new Map<string, Promise<string>>();
 const groupIconSrcCache = new Map<string, string>();
 const groupIconLoadingCache = new Map<string, Promise<string>>();
 
@@ -85,26 +86,6 @@ const getIconUrlCacheValue = (url: string) => {
     return url;
   }
 };
-
-const hashString = (value: string) => {
-  let hashA = 0x811c9dc5;
-  let hashB = 0x811c9dc5 ^ 0x9e3779b9;
-
-  for (let i = 0; i < value.length; i += 1) {
-    const charCode = value.charCodeAt(i);
-    hashA ^= charCode;
-    hashA = Math.imul(hashA, 0x01000193);
-    hashB ^= charCode;
-    hashB = Math.imul(hashB, 0x85ebca6b);
-  }
-
-  return `${(hashA >>> 0).toString(16).padStart(8, "0")}${(hashB >>> 0)
-    .toString(16)
-    .padStart(8, "0")}`;
-};
-
-const getGroupIconCacheKey = (groupIcon: string) =>
-  hashString(getIconUrlCacheValue(groupIcon));
 
 const getFileName = (url: string) => {
   try {
@@ -157,34 +138,45 @@ const sha256Hex = async (value: string) => {
     .join("");
 };
 
-const getIconCacheFileName = async (groupIcon: string) => {
-  const { stem, extension } = splitFileName(getFileName(groupIcon));
+const getGroupIconCacheKey = (groupIcon: string) => {
   const iconUrlCacheValue = getIconUrlCacheValue(groupIcon);
-  const hash = (await sha256Hex(iconUrlCacheValue)).slice(0, ICON_HASH_LENGTH);
-  return `${sanitizeFileName(stem)}-${hash}${sanitizeExtension(extension)}`;
+  const cachedCacheKey = groupIconCacheKeyCache.get(iconUrlCacheValue);
+  if (cachedCacheKey) return cachedCacheKey;
+
+  const cacheKey = sha256Hex(iconUrlCacheValue).then((hash) =>
+    hash.slice(0, ICON_HASH_LENGTH),
+  );
+  groupIconCacheKeyCache.set(iconUrlCacheValue, cacheKey);
+  return cacheKey;
+};
+
+const getIconCacheFileName = (groupIcon: string, cacheKey: string) => {
+  const { stem, extension } = splitFileName(getFileName(groupIcon));
+  return `${sanitizeFileName(stem)}-${cacheKey}${sanitizeExtension(extension)}`;
 };
 
 const getGroupIconSrc = (groupIcon: string) => {
-  const cacheKey = getGroupIconCacheKey(groupIcon);
-  const cachedSrc = groupIconSrcCache.get(cacheKey);
-  if (cachedSrc) return Promise.resolve(cachedSrc);
+  return getGroupIconCacheKey(groupIcon).then((cacheKey) => {
+    const cachedSrc = groupIconSrcCache.get(cacheKey);
+    if (cachedSrc) return cachedSrc;
 
-  const loadingSrc = groupIconLoadingCache.get(cacheKey);
-  if (loadingSrc) return loadingSrc;
+    const loadingSrc = groupIconLoadingCache.get(cacheKey);
+    if (loadingSrc) return loadingSrc;
 
-  const loadIcon = getIconCacheFileName(groupIcon)
-    .then((fileName) => downloadIconCache(groupIcon, fileName))
-    .then((iconPath) => {
-      const iconSrc = convertFileSrc(iconPath);
-      groupIconSrcCache.set(cacheKey, iconSrc);
-      return iconSrc;
-    })
-    .finally(() => {
-      groupIconLoadingCache.delete(cacheKey);
-    });
+    const fileName = getIconCacheFileName(groupIcon, cacheKey);
+    const loadIcon = downloadIconCache(groupIcon, fileName)
+      .then((iconPath) => {
+        const iconSrc = convertFileSrc(iconPath);
+        groupIconSrcCache.set(cacheKey, iconSrc);
+        return iconSrc;
+      })
+      .finally(() => {
+        groupIconLoadingCache.delete(cacheKey);
+      });
 
-  groupIconLoadingCache.set(cacheKey, loadIcon);
-  return loadIcon;
+    groupIconLoadingCache.set(cacheKey, loadIcon);
+    return loadIcon;
+  });
 };
 
 const ProxyItemMiniCol = memo(function ProxyItemMiniCol(props: ProxyColProps) {
@@ -237,22 +229,11 @@ export const ProxyRender = memo(function ProxyRender(props: RenderProps) {
   const isHttpIcon = groupIcon.startsWith("http");
   const isDataIcon = groupIcon.startsWith("data");
   const isInlineSvgIcon = groupIcon.startsWith("<svg");
-  const [iconCachePath, setIconCachePath] = useState(() =>
-    isHttpIcon
-      ? (groupIconSrcCache.get(getGroupIconCacheKey(groupIcon)) ?? "")
-      : "",
-  );
+  const [iconCachePath, setIconCachePath] = useState("");
 
   useEffect(() => {
     if (!isHttpIcon) {
       setIconCachePath("");
-      return;
-    }
-
-    const cacheKey = getGroupIconCacheKey(groupIcon);
-    const cachedSrc = groupIconSrcCache.get(cacheKey);
-    if (cachedSrc) {
-      setIconCachePath(cachedSrc);
       return;
     }
 

--- a/src/components/proxy/proxy-render.tsx
+++ b/src/components/proxy/proxy-render.tsx
@@ -10,7 +10,8 @@ import {
   Typography,
 } from "@mui/material";
 import { convertFileSrc } from "@tauri-apps/api/core";
-import { memo, useEffect, useMemo, useState } from "react";
+import { useAsyncEffect } from "ahooks";
+import { memo, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { downloadIconCache } from "@/services/cmds";
@@ -155,7 +156,7 @@ const getIconCacheFileName = (groupIcon: string, cacheKey: string) => {
   return `${sanitizeFileName(stem)}-${cacheKey}${sanitizeExtension(extension)}`;
 };
 
-const getGroupIconSrc = (groupIcon: string) => {
+const getGroupIconSrc = async (groupIcon: string) => {
   return getGroupIconCacheKey(groupIcon).then((cacheKey) => {
     const cachedSrc = groupIconSrcCache.get(cacheKey);
     if (cachedSrc) return cachedSrc;
@@ -231,30 +232,26 @@ export const ProxyRender = memo(function ProxyRender(props: RenderProps) {
   const isInlineSvgIcon = groupIcon.startsWith("<svg");
   const [iconCachePath, setIconCachePath] = useState("");
 
-  useEffect(() => {
-    if (!isHttpIcon) {
+  useAsyncEffect(
+    async function* () {
+      if (!isHttpIcon) {
+        setIconCachePath("");
+        return;
+      }
+
       setIconCachePath("");
-      return;
-    }
 
-    let canceled = false;
-    setIconCachePath("");
-    getGroupIconSrc(groupIcon)
-      .then((iconSrc) => {
-        if (!canceled) {
-          setIconCachePath(iconSrc);
-        }
-      })
-      .catch(() => {
-        if (!canceled) {
-          setIconCachePath("");
-        }
-      });
-
-    return () => {
-      canceled = true;
-    };
-  }, [isHttpIcon, groupIcon]);
+      try {
+        const iconSrc = await getGroupIconSrc(groupIcon);
+        yield;
+        setIconCachePath(iconSrc);
+      } catch {
+        yield;
+        setIconCachePath("");
+      }
+    },
+    [isHttpIcon, groupIcon],
+  );
 
   if (type === 0) {
     return (

--- a/src/components/proxy/proxy-render.tsx
+++ b/src/components/proxy/proxy-render.tsx
@@ -75,11 +75,14 @@ const StyledTypeBox = styled(ListItemTextChild)(({ theme }) => ({
 const GROUP_ICON_STYLE = { marginRight: "12px", borderRadius: "6px" };
 const ICON_FILE_NAME_MAX_LENGTH = 32;
 const ICON_HASH_LENGTH = 16;
-const groupIconCacheKeyCache = new Map<string, Promise<string>>();
+const groupIconMetaCache = new Map<
+  string,
+  Promise<{ cacheKey: string; fileName: string }>
+>();
 const groupIconSrcCache = new Map<string, string>();
 const groupIconLoadingCache = new Map<string, Promise<string>>();
 
-const getIconUrlCacheValue = (url: string) => {
+const normalizeIconUrl = (url: string) => {
   try {
     const iconUrl = new URL(url);
     return `${iconUrl.origin}${iconUrl.pathname}${iconUrl.search}${iconUrl.hash}`;
@@ -88,7 +91,7 @@ const getIconUrlCacheValue = (url: string) => {
   }
 };
 
-const getFileName = (url: string) => {
+const getIconFileName = (url: string) => {
   try {
     const pathname = new URL(url).pathname;
     const fileName = pathname.substring(pathname.lastIndexOf("/") + 1);
@@ -101,7 +104,7 @@ const getFileName = (url: string) => {
   return path.substring(path.lastIndexOf("/") + 1);
 };
 
-const splitFileName = (fileName: string) => {
+const getIconFileParts = (fileName: string) => {
   const extensionIndex = fileName.lastIndexOf(".");
   if (extensionIndex <= 0 || extensionIndex === fileName.length - 1) {
     return { stem: fileName, extension: ".png" };
@@ -139,40 +142,38 @@ const sha256Hex = async (value: string) => {
     .join("");
 };
 
-const getGroupIconCacheKey = (groupIcon: string) => {
-  const iconUrlCacheValue = getIconUrlCacheValue(groupIcon);
-  const cachedCacheKey = groupIconCacheKeyCache.get(iconUrlCacheValue);
-  if (cachedCacheKey) return cachedCacheKey;
+const getGroupIconMeta = (groupIcon: string) => {
+  const normalizedUrl = normalizeIconUrl(groupIcon);
+  const cachedMeta = groupIconMetaCache.get(normalizedUrl);
+  if (cachedMeta) return cachedMeta;
 
-  const cacheKey = sha256Hex(iconUrlCacheValue).then((hash) =>
-    hash.slice(0, ICON_HASH_LENGTH),
-  );
-  groupIconCacheKeyCache.set(iconUrlCacheValue, cacheKey);
-  return cacheKey;
-};
+  const meta = sha256Hex(normalizedUrl).then((hash) => {
+    const cacheKey = hash.slice(0, ICON_HASH_LENGTH);
+    const { stem, extension } = getIconFileParts(getIconFileName(groupIcon));
+    const fileName = `${sanitizeFileName(stem)}-${cacheKey}${sanitizeExtension(
+      extension,
+    )}`;
+    return { cacheKey, fileName };
+  });
 
-const getIconCacheFileName = (groupIcon: string, cacheKey: string) => {
-  const { stem, extension } = splitFileName(getFileName(groupIcon));
-  return `${sanitizeFileName(stem)}-${cacheKey}${sanitizeExtension(extension)}`;
-};
-
-const loadGroupIconSrc = async (groupIcon: string, cacheKey: string) => {
-  const fileName = getIconCacheFileName(groupIcon, cacheKey);
-  const iconPath = await downloadIconCache(groupIcon, fileName);
-  const iconSrc = convertFileSrc(iconPath);
-  groupIconSrcCache.set(cacheKey, iconSrc);
-  return iconSrc;
+  groupIconMetaCache.set(normalizedUrl, meta);
+  return meta;
 };
 
 const getGroupIconSrc = async (groupIcon: string) => {
-  const cacheKey = await getGroupIconCacheKey(groupIcon);
+  const { cacheKey, fileName } = await getGroupIconMeta(groupIcon);
   const cachedSrc = groupIconSrcCache.get(cacheKey);
   if (cachedSrc) return cachedSrc;
 
   const loadingSrc = groupIconLoadingCache.get(cacheKey);
   if (loadingSrc) return await loadingSrc;
 
-  const loadIcon = loadGroupIconSrc(groupIcon, cacheKey).finally(() => {
+  const loadIcon = (async () => {
+    const iconPath = await downloadIconCache(groupIcon, fileName);
+    const iconSrc = convertFileSrc(iconPath);
+    groupIconSrcCache.set(cacheKey, iconSrc);
+    return iconSrc;
+  })().finally(() => {
     groupIconLoadingCache.delete(cacheKey);
   });
 

--- a/src/components/proxy/proxy-render.tsx
+++ b/src/components/proxy/proxy-render.tsx
@@ -147,10 +147,10 @@ const getIconCacheFileName = async (groupIcon: string) => {
   return `${sanitizeFileName(stem)}-${hash}${sanitizeExtension(extension)}`;
 };
 
-const getGroupIconSrc = async (groupIcon: string) => {
+const getGroupIconSrc = (groupIcon: string) => {
   const cacheKey = getGroupIconCacheKey(groupIcon);
   const cachedSrc = groupIconSrcCache.get(cacheKey);
-  if (cachedSrc) return cachedSrc;
+  if (cachedSrc) return Promise.resolve(cachedSrc);
 
   const loadingSrc = groupIconLoadingCache.get(cacheKey);
   if (loadingSrc) return loadingSrc;

--- a/src/components/proxy/proxy-render.tsx
+++ b/src/components/proxy/proxy-render.tsx
@@ -155,8 +155,8 @@ const getGroupIconSrc = async (groupIcon: string) => {
   const loadingSrc = groupIconLoadingCache.get(cacheKey);
   if (loadingSrc) return loadingSrc;
 
-  const fileName = await getIconCacheFileName(groupIcon);
-  const loadIcon = downloadIconCache(groupIcon, fileName)
+  const loadIcon = getIconCacheFileName(groupIcon)
+    .then((fileName) => downloadIconCache(groupIcon, fileName))
     .then((iconPath) => {
       const iconSrc = convertFileSrc(iconPath);
       groupIconSrcCache.set(cacheKey, iconSrc);

--- a/src/components/proxy/proxy-render.tsx
+++ b/src/components/proxy/proxy-render.tsx
@@ -256,7 +256,7 @@ export const ProxyRender = memo(function ProxyRender(props: RenderProps) {
     return () => {
       canceled = true;
     };
-  }, [isHttpIcon, group.name, groupIcon]);
+  }, [isHttpIcon, groupIcon]);
 
   if (type === 0) {
     return (

--- a/src/components/proxy/proxy-render.tsx
+++ b/src/components/proxy/proxy-render.tsx
@@ -234,7 +234,7 @@ export const ProxyRender = memo(function ProxyRender(props: RenderProps) {
   const [iconCachePath, setIconCachePath] = useState("");
 
   useAsyncEffect(
-    async function () {
+    async function* () {
       if (!isHttpIcon) {
         setIconCachePath("");
         return;
@@ -244,8 +244,10 @@ export const ProxyRender = memo(function ProxyRender(props: RenderProps) {
 
       try {
         const iconSrc = await getGroupIconSrc(groupIcon);
+        yield;
         setIconCachePath(iconSrc);
       } catch {
+        yield;
         setIconCachePath("");
       }
     },

--- a/src/components/test/test-item.tsx
+++ b/src/components/test/test-item.tsx
@@ -31,6 +31,9 @@ interface Props {
   onDelete: (uid: string) => void;
 }
 
+const encodeSvgDataUri = (svg: string) =>
+  `data:image/svg+xml,${encodeURIComponent(svg)}`;
+
 export const TestItem = (props: Props) => {
   const { isDragging, sx, itemData, onEdit, onDelete: onDeleteItem } = props;
 
@@ -120,10 +123,7 @@ export const TestItem = (props: Props) => {
                 <img src={icon} height="40px" />
               )}
               {icon.trim().startsWith("<svg") && (
-                <img
-                  src={`data:image/svg+xml;base64,${btoa(icon)}`}
-                  height="40px"
-                />
+                <img src={encodeSvgDataUri(icon)} height="40px" />
               )}
             </Box>
           ) : (


### PR DESCRIPTION
## 变更概述
- 为代理组 HTTP 图标新增模块级本地资源 URL 缓存
- 复用同一个图标下载 Promise，避免虚拟列表重复挂载时并发重复下载
- 图标本地缓存路径准备好后再渲染 HTTP 图标，避免回退到远程 URL 触发浏览器重复请求

## 主要改动
- 在 `src/components/proxy/proxy-render.tsx` 中新增 `groupIconSrcCache` 和 `groupIconLoadingCache`
- 移除每个 `ProxyRender` 实例内独立的 `useMemoizedFn` 下载逻辑
- 统一代理组图标样式常量，减少重复对象创建

## 影响范围
- 仅影响代理页分组头部 HTTP 图标加载方式
- data URL 和内联 SVG 图标仍按原方式展示

## 验证情况
- `pnpm exec eslint src/components/proxy/proxy-render.tsx --max-warnings=0`
- `pnpm exec tsc --noEmit`
- GitNexus impact: `ProxyGroups` LOW，`ProxyRender` LOW
- GitNexus detect-changes: risk low，0 affected processes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 优化群组图标加载：引入内存缓存与请求去重，提高图标获取速度并减少重复下载。
  * 调整远程图标渲染：仅在缓存就绪并已准备好时显示 HTTP 远程图标，避免回退显示原始图标数据，减少闪烁与错位。
  * 保持数据图标与内联 SVG 的即时渲染与样式行为不变。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->