### PR TITLE
feat(connections): add scroll to top button

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -33,6 +33,7 @@
       "resetToDefault": "Reset to Default",
       "expandAll": "Expand All",
       "collapseAll": "Collapse All",
+      "scrollToTop": "Scroll to Top",
       "exit": "Exit"
     },
     "status": {

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -33,6 +33,7 @@
       "resetToDefault": "بازنشانی به پیش‌فرض",
       "expandAll": "باز کردن همه",
       "collapseAll": "بستن همه",
+      "scrollToTop": "رفتن به بالا",
       "exit": "خروج"
     },
     "status": {

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -33,6 +33,7 @@
       "resetToDefault": "Сбросить настройки по умолчанию",
       "expandAll": "Расширить все",
       "collapseAll": "Свернуть все",
+      "scrollToTop": "Прокрутить вверх",
       "exit": "Выход"
     },
     "status": {

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -33,6 +33,7 @@
       "resetToDefault": "重置为默认值",
       "expandAll": "全部展开",
       "collapseAll": "全部折叠",
+      "scrollToTop": "回到顶部",
       "exit": "退出"
     },
     "status": {

--- a/src/pages/connections.tsx
+++ b/src/pages/connections.tsx
@@ -281,7 +281,7 @@ const ConnectionsPage = () => {
               sx={{
                 position: "absolute",
                 right: 16,
-                bottom: !isActiveTab && filterConn.length > 0 ? 80 : 16,
+                bottom: isActiveTab ? 16 : 80,
               }}
               color="primary"
               onClick={scrollToTop}>

--- a/src/pages/connections.tsx
+++ b/src/pages/connections.tsx
@@ -15,7 +15,7 @@ import {
   Zoom,
 } from "@mui/material";
 import { useLockFn } from "ahooks";
-import { useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { closeAllConnections, closeConnection } from "tauri-plugin-mihomo-api";
@@ -113,7 +113,7 @@ const ConnectionsPage = () => {
     }
   });
 
-  const scrollToTop = () => {
+  const scrollToTop = useCallback(() => {
     if (isTableLayout) {
       tableContainerRef.current?.scrollTo({ top: 0, behavior: "smooth" });
       return;
@@ -124,7 +124,7 @@ const ConnectionsPage = () => {
       align: "start",
       behavior: "smooth",
     });
-  };
+  }, [isTableLayout]);
 
   return (
     <BasePage

--- a/src/pages/connections.tsx
+++ b/src/pages/connections.tsx
@@ -15,7 +15,7 @@ import {
   Zoom,
 } from "@mui/material";
 import { useLockFn } from "ahooks";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { closeAllConnections, closeConnection } from "tauri-plugin-mihomo-api";
@@ -42,6 +42,11 @@ import parseTraffic from "@/utils/parse-traffic";
 
 type OrderFunc = (list: IClosedConnectionItem[]) => IClosedConnectionItem[];
 
+const SCROLL_TOP_VISIBLE_THRESHOLD = 240;
+
+const getScrollerTop = (scroller: HTMLElement | Window) =>
+  "scrollY" in scroller ? scroller.scrollY : scroller.scrollTop;
+
 const ConnectionsPage = () => {
   const { t } = useTranslation();
   const [match, setMatch] = useState(() => (_: string) => true);
@@ -54,6 +59,8 @@ const ConnectionsPage = () => {
   const [tabName, setTabName] = useState("active");
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<VirtuosoHandle>(null);
+  const listScrollerRef = useRef<HTMLElement | Window | null>(null);
+  const [showScrollTop, setShowScrollTop] = useState(false);
 
   const isTableLayout = connLayout === "table";
   const isActiveTab = tabName === "active";
@@ -124,6 +131,37 @@ const ConnectionsPage = () => {
       });
     }
   }, [isTableLayout]);
+
+  const handleListScrollerRef = useCallback(
+    (ref: HTMLElement | Window | null) => {
+      listScrollerRef.current = ref;
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const scroller = isTableLayout
+      ? tableContainerRef.current
+      : listScrollerRef.current;
+
+    if (!scroller) {
+      setShowScrollTop(false);
+      return;
+    }
+
+    const updateScrollTopVisible = () => {
+      setShowScrollTop(getScrollerTop(scroller) > SCROLL_TOP_VISIBLE_THRESHOLD);
+    };
+
+    updateScrollTopVisible();
+    scroller.addEventListener("scroll", updateScrollTopVisible, {
+      passive: true,
+    });
+
+    return () => {
+      scroller.removeEventListener("scroll", updateScrollTopVisible);
+    };
+  }, [isTableLayout, tabName]);
 
   return (
     <BasePage
@@ -258,6 +296,7 @@ const ConnectionsPage = () => {
           ) : (
             <Virtuoso
               ref={listRef}
+              scrollerRef={handleListScrollerRef}
               data={filterConn}
               itemContent={(_, item) => (
                 <ConnectionItem
@@ -273,7 +312,7 @@ const ConnectionsPage = () => {
           )}
         </Box>
         <ConnectionDetail ref={detailRef} />
-        <Zoom in={filterConn.length > 0} unmountOnExit>
+        <Zoom in={showScrollTop} unmountOnExit>
           <Tooltip title={t("common.actions.scrollToTop")}>
             <Fab
               size="medium"

--- a/src/pages/connections.tsx
+++ b/src/pages/connections.tsx
@@ -1,5 +1,6 @@
 import DeleteForeverRounded from "@mui/icons-material/DeleteForeverRounded";
 import Download from "@mui/icons-material/Download";
+import KeyboardArrowUpRounded from "@mui/icons-material/KeyboardArrowUpRounded";
 import TableChartRounded from "@mui/icons-material/TableChartRounded";
 import TableRowsRounded from "@mui/icons-material/TableRowsRounded";
 import Upload from "@mui/icons-material/Upload";
@@ -16,7 +17,7 @@ import {
 import { useLockFn } from "ahooks";
 import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Virtuoso } from "react-virtuoso";
+import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { closeAllConnections, closeConnection } from "tauri-plugin-mihomo-api";
 
 import {
@@ -52,6 +53,7 @@ const ConnectionsPage = () => {
   const setOrderType = useConnectionsStore((s) => s.setOrderType);
   const [tabName, setTabName] = useState("active");
   const tableContainerRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<VirtuosoHandle>(null);
 
   const isTableLayout = connLayout === "table";
   const isActiveTab = tabName === "active";
@@ -111,6 +113,19 @@ const ConnectionsPage = () => {
     }
   });
 
+  const scrollToTop = () => {
+    if (isTableLayout) {
+      tableContainerRef.current?.scrollTo({ top: 0, behavior: "smooth" });
+      return;
+    }
+
+    listRef.current?.scrollToIndex({
+      index: 0,
+      align: "start",
+      behavior: "smooth",
+    });
+  };
+
   return (
     <BasePage
       full
@@ -167,7 +182,7 @@ const ConnectionsPage = () => {
           </div>
         </div>
       }>
-      <div className="h-full w-full overflow-hidden">
+      <div className="relative h-full w-full overflow-hidden">
         <Box
           sx={{
             mb: "10px",
@@ -243,6 +258,7 @@ const ConnectionsPage = () => {
             />
           ) : (
             <Virtuoso
+              ref={listRef}
               data={filterConn}
               itemContent={(_, item) => (
                 <ConnectionItem
@@ -258,6 +274,21 @@ const ConnectionsPage = () => {
           )}
         </Box>
         <ConnectionDetail ref={detailRef} />
+        <Zoom in={filterConn.length > 0} unmountOnExit>
+          <Tooltip title={t("common.actions.scrollToTop")}>
+            <Fab
+              size="medium"
+              sx={{
+                position: "absolute",
+                right: 16,
+                bottom: !isActiveTab && filterConn.length > 0 ? 80 : 16,
+              }}
+              color="primary"
+              onClick={scrollToTop}>
+              <KeyboardArrowUpRounded />
+            </Fab>
+          </Tooltip>
+        </Zoom>
         <Zoom in={!isActiveTab && filterConn.length > 0} unmountOnExit>
           <Fab
             size="medium"

--- a/src/pages/connections.tsx
+++ b/src/pages/connections.tsx
@@ -144,7 +144,7 @@ const ConnectionsPage = () => {
       ? tableContainerRef.current
       : listScrollerRef.current;
 
-    if (!scroller) {
+    if (!scroller || filterConn.length === 0) {
       setShowScrollTop(false);
       return;
     }
@@ -161,7 +161,7 @@ const ConnectionsPage = () => {
     return () => {
       scroller.removeEventListener("scroll", updateScrollTopVisible);
     };
-  }, [isTableLayout, tabName]);
+  }, [filterConn.length, isTableLayout, tabName]);
 
   return (
     <BasePage

--- a/src/pages/connections.tsx
+++ b/src/pages/connections.tsx
@@ -140,6 +140,14 @@ const ConnectionsPage = () => {
   );
 
   useEffect(() => {
+    console.log(
+      "filterConn.length:",
+      filterConn.length,
+      "isTableLayout:",
+      isTableLayout,
+      "tabName:",
+      tabName,
+    );
     const scroller = isTableLayout
       ? tableContainerRef.current
       : listScrollerRef.current;
@@ -161,7 +169,7 @@ const ConnectionsPage = () => {
     return () => {
       scroller.removeEventListener("scroll", updateScrollTopVisible);
     };
-  }, [filterConn.length, isTableLayout, tabName]);
+  }, [filterConn.length > 0, isTableLayout, tabName]);
 
   return (
     <BasePage

--- a/src/pages/connections.tsx
+++ b/src/pages/connections.tsx
@@ -116,14 +116,13 @@ const ConnectionsPage = () => {
   const scrollToTop = useCallback(() => {
     if (isTableLayout) {
       tableContainerRef.current?.scrollTo({ top: 0, behavior: "smooth" });
-      return;
+    } else {
+      listRef.current?.scrollToIndex({
+        index: 0,
+        align: "start",
+        behavior: "smooth",
+      });
     }
-
-    listRef.current?.scrollToIndex({
-      index: 0,
-      align: "start",
-      behavior: "smooth",
-    });
   }, [isTableLayout]);
 
   return (

--- a/src/pages/connections.tsx
+++ b/src/pages/connections.tsx
@@ -140,14 +140,6 @@ const ConnectionsPage = () => {
   );
 
   useEffect(() => {
-    console.log(
-      "filterConn.length:",
-      filterConn.length,
-      "isTableLayout:",
-      isTableLayout,
-      "tabName:",
-      tabName,
-    );
     const scroller = isTableLayout
       ? tableContainerRef.current
       : listScrollerRef.current;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 在连接页面新增“回到顶部”浮动按钮：当内容超过滚动阈值时显示，支持平滑回到顶部并根据当前标签调整位置。

* **多语言支持**
  * 添加“回到顶部”操作的英文、波斯文、俄文和中文翻译。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->