### PR TITLE
feat(proxy): add proxy group tools component

### DIFF
--- a/src/components/proxy/proxy-group-tools.tsx
+++ b/src/components/proxy/proxy-group-tools.tsx
@@ -100,8 +100,6 @@ export const ProxyGroupTools = memo(function ProxyGroupTools(props: Props) {
             e.stopPropagation();
           }}
           onChange={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
             const text = e.target.value;
             setFilterTextInp(text);
             filterChange(text);
@@ -130,8 +128,6 @@ export const ProxyGroupTools = memo(function ProxyGroupTools(props: Props) {
             e.stopPropagation();
           }}
           onChange={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
             headStateActions.setTestUrl(e.target.value);
           }}
           sx={{

--- a/src/components/proxy/proxy-group-tools.tsx
+++ b/src/components/proxy/proxy-group-tools.tsx
@@ -31,7 +31,7 @@ interface Props {
   onCheckDelay: () => void;
 }
 
-export const ProxyGroupTools = memo(function ProxyHead(props: Props) {
+export const ProxyGroupTools = memo(function ProxyGroupTools(props: Props) {
   const { sx = {}, groupName } = props;
   const currentProfileUid = useProfilesStore(
     (s) => s.currentProfile?.uid ?? "",
@@ -146,7 +146,7 @@ export const ProxyGroupTools = memo(function ProxyHead(props: Props) {
         size="small"
         color="inherit"
         title={t("common.fields.location")}
-        onClick={async (e) => {
+        onClick={(e) => {
           e.preventDefault();
           e.stopPropagation();
           props.onLocation();

--- a/src/components/proxy/proxy-group-tools.tsx
+++ b/src/components/proxy/proxy-group-tools.tsx
@@ -1,0 +1,250 @@
+import AccessTimeRounded from "@mui/icons-material/AccessTimeRounded";
+import FilterAltOffRounded from "@mui/icons-material/FilterAltOffRounded";
+import FilterAltRounded from "@mui/icons-material/FilterAltRounded";
+import MyLocationRounded from "@mui/icons-material/MyLocationRounded";
+import NetworkCheckRounded from "@mui/icons-material/NetworkCheckRounded";
+import SortByAlphaRounded from "@mui/icons-material/SortByAlphaRounded";
+import SortRounded from "@mui/icons-material/SortRounded";
+import VisibilityOffRounded from "@mui/icons-material/VisibilityOffRounded";
+import VisibilityRounded from "@mui/icons-material/VisibilityRounded";
+import WifiTetheringOffRounded from "@mui/icons-material/WifiTetheringOffRounded";
+import WifiTetheringRounded from "@mui/icons-material/WifiTetheringRounded";
+import { Box, IconButton, SxProps, TextField } from "@mui/material";
+import debounce from "lodash-es/debounce";
+import { memo, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import delayManager from "@/services/delay";
+import { useProfilesStore, useVergeStore } from "@/stores";
+import {
+  createScopedHeadStateActions,
+  DEFAULT_STATE,
+  useProxyHeadStateStore,
+} from "@/stores/proxyHeadStateStore";
+
+import type { ProxySortType } from "./use-filter-sort";
+
+interface Props {
+  sx?: SxProps;
+  groupName: string;
+  onLocation: () => void;
+  onCheckDelay: () => void;
+}
+
+export const ProxyGroupTools = memo(function ProxyHead(props: Props) {
+  const { sx = {}, groupName } = props;
+  const currentProfileUid = useProfilesStore(
+    (s) => s.currentProfile?.uid ?? "",
+  );
+  const headState = useProxyHeadStateStore((state) =>
+    currentProfileUid
+      ? (state.headStates[currentProfileUid]?.[groupName] ?? DEFAULT_STATE)
+      : DEFAULT_STATE,
+  );
+  const headStateActions = useMemo(
+    () =>
+      createScopedHeadStateActions({ current: currentProfileUid, groupName }),
+    [currentProfileUid, groupName],
+  );
+
+  const { showType, sortType, filterText, textState, testUrl } = headState;
+  const [filterTextInp, setFilterTextInp] = useState(filterText);
+
+  const { t } = useTranslation();
+  const [autoFocus, setAutoFocus] = useState(false);
+
+  useEffect(() => {
+    // fix the focus conflict
+    const timer = setTimeout(() => setAutoFocus(true), 100);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const defaultLatencyTest = useVergeStore((s) => s.verge.default_latency_test);
+
+  useEffect(() => {
+    delayManager.setUrl(groupName, testUrl || defaultLatencyTest);
+  }, [groupName, testUrl, defaultLatencyTest]);
+
+  const filterChange = useMemo(
+    () =>
+      debounce((text: string) => {
+        headStateActions.setFilterText(text);
+      }, 500),
+    [headStateActions],
+  );
+
+  useEffect(() => {
+    return () => {
+      filterChange.cancel();
+    };
+  }, [filterChange]);
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 0.5,
+        ...sx,
+      }}>
+      {textState === "filter" && (
+        <TextField
+          autoFocus={autoFocus}
+          hiddenLabel
+          value={filterTextInp}
+          size="small"
+          variant="outlined"
+          placeholder={t("common.search.filterConditions")}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+          onChange={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            const text = e.target.value;
+            setFilterTextInp(text);
+            filterChange(text);
+          }}
+          sx={{
+            ml: 0.5,
+            flex: "1 1 auto",
+            minWidth: 150,
+            input: { py: 0.4, px: 1 },
+          }}
+        />
+      )}
+
+      {textState === "url" && (
+        <TextField
+          autoFocus={autoFocus}
+          hiddenLabel
+          autoSave="off"
+          autoComplete="off"
+          value={testUrl}
+          size="small"
+          variant="outlined"
+          placeholder={t("pages.proxies.actions.delayCheckUrl")}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+          onChange={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            headStateActions.setTestUrl(e.target.value);
+          }}
+          sx={{
+            ml: 0.5,
+            flex: "1 1 auto",
+            minWidth: 150,
+            input: { py: 0.4, px: 1 },
+          }}
+        />
+      )}
+      <IconButton
+        size="small"
+        color="inherit"
+        title={t("common.fields.location")}
+        onClick={async (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          props.onLocation();
+        }}>
+        <MyLocationRounded fontSize="inherit" />
+      </IconButton>
+
+      <IconButton
+        size="small"
+        color="inherit"
+        title={t("pages.proxies.actions.delayCheck")}
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          // Remind the user that it is custom test url
+          if (testUrl?.trim() && textState !== "filter") {
+            headStateActions.setTextState("url");
+          }
+          props.onCheckDelay();
+        }}>
+        <NetworkCheckRounded fontSize="inherit" />
+      </IconButton>
+
+      <IconButton
+        size="small"
+        color="inherit"
+        title={
+          [
+            t("pages.proxies.sort.default"),
+            t("pages.proxies.sort.delay"),
+            t("pages.proxies.sort.name"),
+          ][sortType]
+        }
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          headStateActions.setSortType(((sortType + 1) % 3) as ProxySortType);
+        }}>
+        {sortType !== 1 && sortType !== 2 && <SortRounded fontSize="inherit" />}
+        {sortType === 1 && <AccessTimeRounded fontSize="inherit" />}
+        {sortType === 2 && <SortByAlphaRounded fontSize="inherit" />}
+      </IconButton>
+
+      <IconButton
+        size="small"
+        color="inherit"
+        title={t("pages.proxies.actions.delayCheckUrl")}
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          headStateActions.setTextState(textState === "url" ? null : "url");
+        }}>
+        {textState === "url" ? (
+          <WifiTetheringRounded fontSize="inherit" />
+        ) : (
+          <WifiTetheringOffRounded fontSize="inherit" />
+        )}
+      </IconButton>
+
+      <IconButton
+        size="small"
+        color="inherit"
+        title={
+          showType
+            ? t("pages.proxies.view.basic")
+            : t("pages.proxies.view.detail")
+        }
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          headStateActions.setShowType(!showType);
+        }}>
+        {showType ? (
+          <VisibilityRounded fontSize="inherit" />
+        ) : (
+          <VisibilityOffRounded fontSize="inherit" />
+        )}
+      </IconButton>
+
+      <IconButton
+        size="small"
+        color="inherit"
+        title={t("common.search.filter")}
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          setFilterTextInp("");
+          headStateActions.setTextState(
+            textState === "filter" ? null : "filter",
+          );
+          headStateActions.setFilterText("");
+        }}>
+        {textState === "filter" ? (
+          <FilterAltRounded fontSize="inherit" />
+        ) : (
+          <FilterAltOffRounded fontSize="inherit" />
+        )}
+      </IconButton>
+    </Box>
+  );
+});

--- a/src/components/proxy/proxy-groups.tsx
+++ b/src/components/proxy/proxy-groups.tsx
@@ -29,7 +29,7 @@ interface Props {
 }
 
 /// 固定的组高度，用于手动计算组高度偏移量
-export const FIXED_GROUP_HEIGHT = 76;
+export const FIXED_GROUP_HEIGHT = 70;
 /// 预估的项高度，用于 tanstack/react-virtual 动态计算高度
 const ESTIMATED_PROXY_ITEM_HEIGHT = 64;
 

--- a/src/components/proxy/proxy-groups.tsx
+++ b/src/components/proxy/proxy-groups.tsx
@@ -29,7 +29,7 @@ interface Props {
 }
 
 /// 固定的组高度，用于手动计算组高度偏移量
-export const FIXED_GROUP_HEIGHT = 70;
+export const FIXED_GROUP_HEIGHT = 76;
 /// 预估的项高度，用于 tanstack/react-virtual 动态计算高度
 const ESTIMATED_PROXY_ITEM_HEIGHT = 64;
 

--- a/src/components/proxy/proxy-render.tsx
+++ b/src/components/proxy/proxy-render.tsx
@@ -22,8 +22,8 @@ import {
   DEFAULT_STATE,
 } from "@/stores/proxyHeadStateStore";
 
+import { ProxyGroupTools } from "./proxy-group-tools";
 import { FIXED_GROUP_HEIGHT } from "./proxy-groups";
-import { ProxyHead } from "./proxy-head";
 import { ProxyItem } from "./proxy-item";
 import { ProxyItemMini } from "./proxy-item-mini";
 import type { IRenderItem } from "./use-render-list";
@@ -47,17 +47,11 @@ const StyledPrimary = styled("span")`
   font-size: 15px;
   font-weight: 700;
   line-height: 1.5;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 `;
-const StyledSubtitle = styled("span")`
-  font-size: 13px;
-  overflow: hidden;
-  color: text.secondary;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-`;
+const StyledSubtitle = styled("span")(({ theme }) => ({
+  fontSize: "13px",
+  color: theme.palette.text.secondary,
+}));
 
 const ListItemTextChild = styled("span")`
   display: block;
@@ -326,28 +320,24 @@ export const ProxyRender = memo(function ProxyRender(props: RenderProps) {
           </>
         )}
         <ListItemText
+          sx={{ minWidth: 0 }}
           primary={<StyledPrimary>{group.name}</StyledPrimary>}
           secondary={
-            <ListItemTextChild
-              sx={{
-                overflow: "hidden",
-                display: "flex",
-                alignItems: "center",
-                pt: "2px",
-              }}>
-              <span style={{ marginTop: "2px", display: "block" }}>
-                <StyledTypeBox>{group.type}</StyledTypeBox>
-                <StyledSubtitle sx={{ color: "text.secondary" }}>
-                  {group.now}
-                </StyledSubtitle>
-              </span>
-            </ListItemTextChild>
+            <span className="mt-0.5 inline-block truncate">
+              <StyledTypeBox>{group.type}</StyledTypeBox>
+              <StyledSubtitle>{group.now}</StyledSubtitle>
+            </span>
           }
           slotProps={{
-            secondary: {
-              sx: { display: "flex", alignItems: "center", color: "#ccc" },
-            },
+            secondary: { sx: { display: "flex", alignItems: "center" } },
           }}
+        />
+
+        <ProxyGroupTools
+          sx={{ pr: 3 }}
+          groupName={group.name}
+          onLocation={() => onLocation(group)}
+          onCheckDelay={() => onCheckAll(group.name)}
         />
         {headState?.open ? <ExpandLessRounded /> : <ExpandMoreRounded />}
       </ListItemButton>
@@ -355,14 +345,15 @@ export const ProxyRender = memo(function ProxyRender(props: RenderProps) {
   }
 
   if (type === 1) {
-    return (
-      <ProxyHead
-        sx={{ pl: 2, pr: 3, pt: 1 }}
-        groupName={group.name}
-        onLocation={() => onLocation(group)}
-        onCheckDelay={() => onCheckAll(group.name)}
-      />
-    );
+    return null;
+    // return (
+    //   <ProxyHead
+    //     sx={{ pl: 2, pr: 3, pt: 1 }}
+    //     groupName={group.name}
+    //     onLocation={() => onLocation(group)}
+    //     onCheckDelay={() => onCheckAll(group.name)}
+    //   />
+    // );
   }
 
   if (type === 2) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 为代理组新增工具栏：支持延迟测试 URL 输入、文本过滤（带 500ms 防抖）、排序循环、快速执行延迟检查与定位操作，以及视图切换（简略/详细）。

* **改进**
  * 优化代理组头部显示与样式结构，调整渲染逻辑以简化部分组的展示行为并改善布局与截断效果。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->