### PR TITLE
feat(rules): add domain and CIDR rule search

### DIFF
--- a/src/components/rule/rule-item.tsx
+++ b/src/components/rule/rule-item.tsx
@@ -59,7 +59,10 @@ const parseColor = (text: string) => {
 export const RuleItem = (props: Props) => {
   const { index, value, matchPayloadItems } = props;
   const isRuleSet = value.type === "RuleSet";
-  const expanded = isRuleSet && value.expanded;
+  const expanded = useRulesStateStore((s) => {
+    if (!isRuleSet) return false;
+    return !!s.rules.find((rule) => rule.payload === value.payload)?.expanded;
+  });
   const toggleRuleExpanded = useRulesStateStore((s) => s.toggleRuleExpanded);
   const disableRules = useRulesStateStore((s) => s.disableRules);
 

--- a/src/components/rule/rule-item.tsx
+++ b/src/components/rule/rule-item.tsx
@@ -58,16 +58,23 @@ const parseColor = (text: string) => {
 
 export const RuleItem = (props: Props) => {
   const { index, value, matchPayloadItems } = props;
-  const isRuleSet = value.type === "RuleSet";
-  const expanded = useRulesStateStore((s) => {
-    if (!isRuleSet) return false;
-    return !!s.rules.find((rule) => rule.payload === value.payload)?.expanded;
-  });
+  const currentValue = useRulesStateStore(
+    (s) =>
+      s.rules.find(
+        (rule) => rule.index === value.index && rule.payload === value.payload,
+      ) ?? value,
+  );
+  const isRuleSet = currentValue.type === "RuleSet";
+  const expanded = isRuleSet && currentValue.expanded;
   const toggleRuleExpanded = useRulesStateStore((s) => s.toggleRuleExpanded);
   const disableRules = useRulesStateStore((s) => s.disableRules);
 
-  const showHit = !!(value.extra?.hitCount && value.extra.hitCount > 0);
-  const showMiss = !!(value.extra?.missCount && value.extra.missCount > 0);
+  const showHit = !!(
+    currentValue.extra?.hitCount && currentValue.extra.hitCount > 0
+  );
+  const showMiss = !!(
+    currentValue.extra?.missCount && currentValue.extra.missCount > 0
+  );
 
   return (
     <Card
@@ -80,7 +87,7 @@ export const RuleItem = (props: Props) => {
           const bgcolor = mode === "light" ? "#ffffff" : "#282A36";
           return {
             bgcolor,
-            opacity: value.extra?.disabled ? action.disabledOpacity : 1,
+            opacity: currentValue.extra?.disabled ? action.disabledOpacity : 1,
             "& ::-webkit-scrollbar-thumb": {
               backgroundColor: alpha(primary.main, 0.35),
             },
@@ -100,7 +107,7 @@ export const RuleItem = (props: Props) => {
             }),
             borderBottom: "1px solid var(--divider-color)",
           }),
-          ...(value.extra?.disabled && {
+          ...(currentValue.extra?.disabled && {
             bgcolor: theme.palette.action.disabledBackground,
             ":hover": {
               bgcolor: theme.palette.action.disabledBackground,
@@ -108,18 +115,25 @@ export const RuleItem = (props: Props) => {
           }),
         })}
         onClick={() => {
-          if (value.type === "RuleSet") {
-            toggleRuleExpanded(value.payload);
+          if (currentValue.type === "RuleSet") {
+            toggleRuleExpanded(currentValue.payload);
           }
         }}>
         <div className="w-full">
           <div className="flex w-full items-center justify-center">
             <Switch
               size="small"
-              checked={!value.extra?.disabled}
-              onChange={async (e) => {
+              checked={!currentValue.extra?.disabled}
+              onClick={(e) => {
                 e.stopPropagation();
-                await disableRules({ [value.index]: !value.extra?.disabled });
+              }}
+              onMouseDown={(e) => {
+                e.stopPropagation();
+              }}
+              onChange={async () => {
+                await disableRules({
+                  [currentValue.index]: !currentValue.extra?.disabled,
+                });
               }}
               sx={{ mr: 0.5 }}
             />
@@ -137,14 +151,16 @@ export const RuleItem = (props: Props) => {
                   component="h6"
                   variant="subtitle1"
                   color={
-                    value.extra?.disabled ? "text.disabled" : "text.primary"
+                    currentValue.extra?.disabled
+                      ? "text.disabled"
+                      : "text.primary"
                   }
                   sx={
-                    value.extra?.disabled
+                    currentValue.extra?.disabled
                       ? { textDecoration: "line-through" }
                       : undefined
                   }>
-                  {value.payload || "-"}
+                  {currentValue.payload || "-"}
                 </Typography>
               </div>
 
@@ -154,10 +170,10 @@ export const RuleItem = (props: Props) => {
                   variant="body2"
                   color="text.secondary"
                   sx={{ mr: 3, minWidth: 120, display: "inline-block" }}>
-                  {value.type}
+                  {currentValue.type}
                   {isRuleSet && (
                     <span className="text-primary-main bg-primary-alpha-20 ml-2 inline-block rounded-full px-2 text-xs">
-                      {value.behavior}
+                      {currentValue.behavior}
                     </span>
                   )}
                 </Typography>
@@ -165,13 +181,13 @@ export const RuleItem = (props: Props) => {
                 <Typography
                   component="span"
                   variant="body2"
-                  color={parseColor(value.proxy)}
+                  color={parseColor(currentValue.proxy)}
                   sx={
-                    value.extra?.disabled
+                    currentValue.extra?.disabled
                       ? { textDecoration: "line-through" }
                       : undefined
                   }>
-                  {value.proxy}
+                  {currentValue.proxy}
                 </Typography>
               </div>
             </div>
@@ -180,11 +196,11 @@ export const RuleItem = (props: Props) => {
               {isRuleSet && (
                 <div className="flex items-center justify-end">
                   <div className="bg-primary-alpha-20 text-primary-main rounded-full px-2 text-sm">
-                    {value.ruleCount}
+                    {currentValue.ruleCount}
                   </div>
                   <div className="text-primary-main bg-primary-alpha-20 ml-2 flex items-center rounded-full px-2 py-0.5 text-xs">
                     <Update className="mr-1" fontSize="small" />
-                    <span>{dayjs(value.updatedAt).fromNow()}</span>
+                    <span>{dayjs(currentValue.updatedAt).fromNow()}</span>
                   </div>
                 </div>
               )}
@@ -195,13 +211,13 @@ export const RuleItem = (props: Props) => {
                       <div>
                         Hit:
                         <span className="text-primary-main inline-block h-fit w-fit px-1">
-                          {value.extra?.hitCount}
+                          {currentValue.extra?.hitCount}
                         </span>
                       </div>
                       <div>
                         At:
                         <span className="text-primary-main inline-block h-fit w-fit px-1">
-                          {dayjs(value.extra?.hitAt).format(
+                          {dayjs(currentValue.extra?.hitAt).format(
                             "YYYY-MM-DD HH:mm:ss",
                           )}
                         </span>
@@ -249,7 +265,7 @@ export const RuleItem = (props: Props) => {
           sx={[
             ({ palette: { primary, action } }) => ({
               bgcolor: alpha(primary.main, 0.15),
-              ...(value.extra?.disabled && {
+              ...(currentValue.extra?.disabled && {
                 bgcolor: action.disabledBackground,
                 opacity: action.disabledOpacity,
               }),

--- a/src/components/rule/rule-search-box.tsx
+++ b/src/components/rule/rule-search-box.tsx
@@ -1,0 +1,134 @@
+import ClearRounded from "@mui/icons-material/ClearRounded";
+import DnsRounded from "@mui/icons-material/DnsRounded";
+import LanguageRounded from "@mui/icons-material/LanguageRounded";
+import SearchRounded from "@mui/icons-material/SearchRounded";
+import {
+  Box,
+  IconButton,
+  InputAdornment,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
+} from "@mui/material";
+import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { RuleSearchMode, RuleSearchState } from "@/utils/rule-search";
+
+type Props = {
+  onSearch: (state: RuleSearchState) => void;
+};
+
+export const RuleSearchBox = ({ onSearch }: Props) => {
+  const { t } = useTranslation();
+  const [text, setText] = useState("");
+  const [mode, setMode] = useState<RuleSearchMode>("domain");
+
+  const submitSearch = useCallback(
+    (nextMode = mode, nextText = text) => {
+      onSearch({ mode: nextMode, text: nextText.trim() });
+    },
+    [mode, onSearch, text],
+  );
+
+  return (
+    <TextField
+      hiddenLabel
+      fullWidth
+      size="small"
+      autoComplete="off"
+      variant="outlined"
+      spellCheck="false"
+      value={text}
+      placeholder={
+        mode === "domain"
+          ? t("common.search.domainPlaceholder")
+          : t("common.search.cidrPlaceholder")
+      }
+      sx={[
+        {
+          "& .MuiInputBase-root": {
+            pl: 0.5,
+            pr: 0.5,
+          },
+          input: { py: 0.65, px: 1 },
+        },
+        ({ palette: { mode } }) => {
+          return { ...(mode === "light" && { backgroundColor: "#fff" }) };
+        },
+      ]}
+      onChange={(e) => setText(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          submitSearch();
+        }
+      }}
+      slotProps={{
+        input: {
+          startAdornment: (
+            <InputAdornment position="start" sx={{ mr: 0.5 }}>
+              <ToggleButtonGroup
+                exclusive
+                size="small"
+                value={mode}
+                onChange={(_, value: RuleSearchMode | null) => {
+                  if (!value) return;
+                  setMode(value);
+                  submitSearch(value);
+                }}
+                sx={{
+                  "& .MuiToggleButton-root": {
+                    minWidth: 30,
+                    height: 26,
+                    px: 0.75,
+                    py: 0,
+                  },
+                }}>
+                <ToggleButton
+                  value="domain"
+                  aria-label={t("common.search.domain")}>
+                  <Tooltip title={t("common.search.domain")}>
+                    <LanguageRounded fontSize="small" />
+                  </Tooltip>
+                </ToggleButton>
+                <ToggleButton value="cidr" aria-label="CIDR">
+                  <Tooltip title="CIDR">
+                    <DnsRounded fontSize="small" />
+                  </Tooltip>
+                </ToggleButton>
+              </ToggleButtonGroup>
+            </InputAdornment>
+          ),
+          endAdornment: (
+            <Box display="flex" alignItems="center" gap={0.5}>
+              {text !== "" && (
+                <Tooltip title={t("common.actions.clear")}>
+                  <IconButton
+                    size="small"
+                    color="primary"
+                    sx={{ p: 0.5 }}
+                    onClick={() => {
+                      setText("");
+                      submitSearch(mode, "");
+                    }}>
+                    <ClearRounded fontSize="inherit" />
+                  </IconButton>
+                </Tooltip>
+              )}
+              <Tooltip title={t("common.search.filter")}>
+                <IconButton
+                  size="small"
+                  color="primary"
+                  sx={{ p: 0.5 }}
+                  onClick={() => submitSearch()}>
+                  <SearchRounded fontSize="inherit" />
+                </IconButton>
+              </Tooltip>
+            </Box>
+          ),
+        },
+      }}
+    />
+  );
+};

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -82,7 +82,7 @@
       "filterConditions": "Filter conditions",
       "domain": "Domain",
       "domainPlaceholder": "Search domain, e.g. google.com",
-      "cidrPlaceholder": "Search CIDR, e.g. 8.8.8.0/24",
+      "cidrPlaceholder": "Search IP or CIDR, e.g. 8.8.8.8 or 8.8.8.0/24",
       "rulesTotal": "{{count}} rules",
       "rulesMatched": "{{mode}}: {{text}} · {{groups}} groups / {{items}} entries",
       "searching": "Searching...",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -80,6 +80,12 @@
     "search": {
       "filter": "Filter",
       "filterConditions": "Filter conditions",
+      "domain": "Domain",
+      "domainPlaceholder": "Search domain, e.g. google.com",
+      "cidrPlaceholder": "Search CIDR, e.g. 8.8.8.0/24",
+      "rulesTotal": "{{count}} rules",
+      "rulesMatched": "{{mode}}: {{text}} · {{groups}} groups / {{items}} entries",
+      "searching": "Searching...",
       "matchCase": "Match Case",
       "matchWholeWord": "Match Whole Word",
       "useRegularExpression": "Use Regular Expression"

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -82,7 +82,7 @@
       "filterConditions": "شرایط فیلتر",
       "domain": "دامنه",
       "domainPlaceholder": "جستجوی دامنه، مانند google.com",
-      "cidrPlaceholder": "جستجوی CIDR، مانند 8.8.8.0/24",
+      "cidrPlaceholder": "جستجوی IP یا CIDR، مانند 8.8.8.8 یا 8.8.8.0/24",
       "rulesTotal": "{{count}} قاعده",
       "rulesMatched": "{{mode}}: {{text}} · {{groups}} گروه / {{items}} مورد",
       "searching": "در حال جستجو...",

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -80,6 +80,12 @@
     "search": {
       "filter": "فیلتر",
       "filterConditions": "شرایط فیلتر",
+      "domain": "دامنه",
+      "domainPlaceholder": "جستجوی دامنه، مانند google.com",
+      "cidrPlaceholder": "جستجوی CIDR، مانند 8.8.8.0/24",
+      "rulesTotal": "{{count}} قاعده",
+      "rulesMatched": "{{mode}}: {{text}} · {{groups}} گروه / {{items}} مورد",
+      "searching": "در حال جستجو...",
       "matchCase": "تطبیق حروف کوچک و بزرگ",
       "matchWholeWord": "تطبیق کل کلمه",
       "useRegularExpression": "استفاده از عبارت منظم"

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -80,6 +80,12 @@
     "search": {
       "filter": "Фильтр",
       "filterConditions": "Условия фильтрации",
+      "domain": "Домен",
+      "domainPlaceholder": "Поиск домена, например google.com",
+      "cidrPlaceholder": "Поиск CIDR, например 8.8.8.0/24",
+      "rulesTotal": "Всего правил: {{count}}",
+      "rulesMatched": "{{mode}}: {{text}} · {{groups}} групп / {{items}} записей",
+      "searching": "Поиск...",
       "matchCase": "Учитывать регистр",
       "matchWholeWord": "Полное совпадение слова",
       "useRegularExpression": "Использовать регулярные выражения"

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -82,7 +82,7 @@
       "filterConditions": "Условия фильтрации",
       "domain": "Домен",
       "domainPlaceholder": "Поиск домена, например google.com",
-      "cidrPlaceholder": "Поиск CIDR, например 8.8.8.0/24",
+      "cidrPlaceholder": "Поиск IP или CIDR, например 8.8.8.8 или 8.8.8.0/24",
       "rulesTotal": "Всего правил: {{count}}",
       "rulesMatched": "{{mode}}: {{text}} · {{groups}} групп / {{items}} записей",
       "searching": "Поиск...",

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -82,7 +82,7 @@
       "filterConditions": "过滤条件",
       "domain": "域名",
       "domainPlaceholder": "搜索域名，例如 google.com",
-      "cidrPlaceholder": "搜索 CIDR，例如 8.8.8.0/24",
+      "cidrPlaceholder": "搜索 IP 或 CIDR，例如 8.8.8.8 或 8.8.8.0/24",
       "rulesTotal": "共 {{count}} 条规则",
       "rulesMatched": "{{mode}}：{{text}} · 命中 {{groups}} 组 / {{items}} 条",
       "searching": "正在搜索...",

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -80,6 +80,12 @@
     "search": {
       "filter": "过滤节点",
       "filterConditions": "过滤条件",
+      "domain": "域名",
+      "domainPlaceholder": "搜索域名，例如 google.com",
+      "cidrPlaceholder": "搜索 CIDR，例如 8.8.8.0/24",
+      "rulesTotal": "共 {{count}} 条规则",
+      "rulesMatched": "{{mode}}：{{text}} · 命中 {{groups}} 组 / {{items}} 条",
+      "searching": "正在搜索...",
       "matchCase": "区分大小写",
       "matchWholeWord": "全字匹配",
       "useRegularExpression": "使用正则表达式"

--- a/src/pages/rules.tsx
+++ b/src/pages/rules.tsx
@@ -1,17 +1,25 @@
 import ExpandIcon from "@mui/icons-material/Expand";
 import VerticalAlignCenterIcon from "@mui/icons-material/VerticalAlignCenter";
-import { Box, IconButton } from "@mui/material";
+import { Box, IconButton, Typography } from "@mui/material";
 import { useAsyncEffect, useInterval } from "ahooks";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState, useTransition } from "react";
 import { useTranslation } from "react-i18next";
+import { BeatLoader } from "react-spinners";
 import { Virtuoso } from "react-virtuoso";
 import { useShallow } from "zustand/react/shallow";
 
-import { BaseEmpty, BasePage, BaseSearchBox } from "@/components/base";
+import { BaseEmpty, BasePage } from "@/components/base";
 import { ProviderButton } from "@/components/rule/provider-button";
 import { RuleItem } from "@/components/rule/rule-item";
+import { RuleSearchBox } from "@/components/rule/rule-search-box";
 import { useRulesStateStore } from "@/stores";
 import { CustomRule } from "@/stores/rulesStateStore";
+import {
+  createRuleSearchMatcher,
+  EMPTY_RULE_SEARCH,
+  normalizeDomain,
+  RuleSearchState,
+} from "@/utils/rule-search";
 
 type CustomRuleWithMatch = CustomRule & {
   matchPayloadItems: string[];
@@ -21,6 +29,7 @@ const RulesPage = () => {
   const { t } = useTranslation();
 
   const rules = useRulesStateStore((s) => s.rules);
+  const rulesDataVersion = useRulesStateStore((s) => s.rulesDataVersion);
   const hasRuleSet = useRulesStateStore(
     useShallow((s) => s.rules.some((i) => i.type === "RuleSet")),
   );
@@ -30,29 +39,63 @@ const RulesPage = () => {
   const expandAllRules = useRulesStateStore((s) => s.expandAllRules);
   const collapseAllRules = useRulesStateStore((s) => s.collapseAllRules);
 
-  const [match, setMatch] = useState(() => (_: string) => true);
+  const [search, setSearch] = useState<RuleSearchState>(EMPTY_RULE_SEARCH);
+  const [isSearchPending, startSearchTransition] = useTransition();
+  const rulesRef = useRef(rules);
+  rulesRef.current = rules;
+
+  const handleSearch = useCallback((nextSearch: RuleSearchState) => {
+    startSearchTransition(() => {
+      setSearch(nextSearch);
+    });
+  }, []);
 
   const filterRules = useMemo(() => {
-    return rules
+    if (!search.text) {
+      return rulesRef.current.map((item) => ({
+        ...item,
+        matchPayloadItems: item.payloadContent ?? [],
+      }));
+    }
+
+    const matchesSearch = createRuleSearchMatcher(search);
+
+    return rulesRef.current
       .map((item) => {
         const newItem: CustomRuleWithMatch = {
           ...item,
-          matchPayloadItems: [],
+          matchPayloadItems: item.payloadContent
+            ? item.payloadContent.filter((payload) =>
+                matchesSearch(item, payload),
+              )
+            : [],
         };
         return newItem;
       })
       .filter((item) => {
         if (item.payloadContent) {
-          item.payloadContent.forEach((rule) => {
-            if (match(rule)) {
-              item.matchPayloadItems?.push(rule);
-            }
-          });
-          return item.matchPayloadItems && item.matchPayloadItems.length > 0;
+          return item.matchPayloadItems.length > 0;
         }
-        return match(item.payload);
+        return matchesSearch(item, item.payload);
       });
-  }, [rules, match]);
+  }, [rulesDataVersion, search]);
+
+  const searchStatus = useMemo(() => {
+    if (!search.text) {
+      return t("common.search.rulesTotal", { count: rules.length });
+    }
+
+    const matchedItems = filterRules.reduce((total, item) => {
+      return total + (item.payloadContent ? item.matchPayloadItems.length : 1);
+    }, 0);
+
+    return t("common.search.rulesMatched", {
+      mode: search.mode === "domain" ? t("common.search.domain") : "CIDR",
+      text: normalizeDomain(search.text),
+      groups: filterRules.length,
+      items: matchedItems,
+    });
+  }, [filterRules, rules.length, search.mode, search.text, t]);
 
   useAsyncEffect(async () => {
     await fetchRules();
@@ -97,23 +140,53 @@ const RulesPage = () => {
           height: "36px",
           display: "flex",
           alignItems: "center",
+          gap: 1,
           boxSizing: "border-box",
         }}>
-        <BaseSearchBox onSearch={(match) => setMatch(() => match)} />
+        <RuleSearchBox onSearch={handleSearch} />
+        <Typography
+          title={searchStatus}
+          variant="caption"
+          color="text.secondary"
+          sx={{
+            flexShrink: 0,
+            maxWidth: "40%",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}>
+          {searchStatus}
+        </Typography>
       </Box>
 
       <Box
         height={"calc(100% - 50px)"}
         sx={{
+          position: "relative",
           boxSizing: "border-box",
           mb: "4px",
           marginLeft: "10px",
           borderRadius: "8px",
         }}>
-        {filterRules.length > 0 ? (
+        {isSearchPending ? (
+          <Box
+            sx={{
+              position: "absolute",
+              inset: 0,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 2,
+            }}>
+            <BeatLoader color="var(--primary-main)" />
+            <Typography className="text-primary-main" variant="body1">
+              {t("common.search.searching")}
+            </Typography>
+          </Box>
+        ) : filterRules.length > 0 ? (
           <Virtuoso
             data={filterRules}
-            totalCount={rules.length}
             itemContent={(index, item) => (
               <RuleItem
                 key={item.index}

--- a/src/stores/rulesStateStore.ts
+++ b/src/stores/rulesStateStore.ts
@@ -17,6 +17,8 @@ export type CustomRule = Rule &
 
 type RulesState = {
   rules: CustomRule[];
+  rulesSignature: string;
+  rulesDataVersion: number;
 };
 
 type RulesActions = {
@@ -31,28 +33,52 @@ type RulesActions = {
 export const useRulesStateStore = create<RulesState & RulesActions>()(
   (set, get) => ({
     rules: [],
+    rulesSignature: "",
+    rulesDataVersion: 0,
     fetchRules: async () => {
       const rules = await getRules();
       const newRules = rules.rules.map(
         (rule) => ({ ...rule, expanded: false }) as CustomRule,
       );
+      const rulesSignature = newRules
+        .map((rule) =>
+          [
+            rule.index,
+            rule.type,
+            rule.payload,
+            rule.proxy,
+            rule.size,
+            JSON.stringify(rule.extra),
+          ].join("\u0000"),
+        )
+        .join("\u0001");
 
       set((state) => {
+        const shouldPreserveRuleState = state.rulesSignature === rulesSignature;
         const existingRulesByPayload = new Map(
           state.rules.map((rule) => [rule.payload, rule]),
         );
 
-        // 基于旧数据合并 expanded 状态
         const mergedRules = newRules.map((newRule) => {
           const existingRule = existingRulesByPayload.get(newRule.payload);
+          if (!shouldPreserveRuleState || !existingRule) {
+            return newRule;
+          }
+
           return {
             ...existingRule,
             ...newRule,
-            expanded: existingRule ? existingRule.expanded : newRule.expanded,
+            expanded: existingRule.expanded,
           };
         });
 
-        return { rules: mergedRules };
+        return {
+          rules: mergedRules,
+          rulesSignature,
+          rulesDataVersion: shouldPreserveRuleState
+            ? state.rulesDataVersion
+            : state.rulesDataVersion + 1,
+        };
       });
     },
 
@@ -93,14 +119,17 @@ export const useRulesStateStore = create<RulesState & RulesActions>()(
           return mergedProviderRule ? { ...rule, ...mergedProviderRule } : rule;
         });
 
-        return { rules: mergedRules };
+        return {
+          rules: mergedRules,
+          rulesDataVersion: state.rulesDataVersion + 1,
+        };
       });
     },
     expandAllRules: () => {
       set((state) => ({
         rules: state.rules.map((rule) => ({
           ...rule,
-          expanded: true,
+          expanded: rule.type === "RuleSet",
         })),
       }));
     },

--- a/src/stores/rulesStateStore.ts
+++ b/src/stores/rulesStateStore.ts
@@ -42,14 +42,9 @@ export const useRulesStateStore = create<RulesState & RulesActions>()(
       );
       const rulesSignature = newRules
         .map((rule) =>
-          [
-            rule.index,
-            rule.type,
-            rule.payload,
-            rule.proxy,
-            rule.size,
-            JSON.stringify(rule.extra),
-          ].join("\u0000"),
+          [rule.index, rule.type, rule.payload, rule.proxy, rule.size].join(
+            "\u0000",
+          ),
         )
         .join("\u0001");
 

--- a/src/utils/rule-search.ts
+++ b/src/utils/rule-search.ts
@@ -207,14 +207,16 @@ const parseIpValue = (value: string) => {
 };
 
 const parseCidrRange = (value: string): IpRange | null => {
-  const [address = "", prefixText] = value.trim().split("/");
+  const parts = value.trim().split("/");
+  if (parts.length > 2) return null;
+  const [address = "", prefixText] = parts;
   const parsedIp = parseIpValue(address);
   if (!parsedIp) return null;
 
   const bitSize = parsedIp.version === 4 ? 32 : 128;
+  if (prefixText !== undefined && !/^\d+$/.test(prefixText)) return null;
   const prefix = prefixText === undefined ? bitSize : Number(prefixText);
   if (!Number.isInteger(prefix) || prefix < 0 || prefix > bitSize) return null;
-
   const hostBits = BigInt(bitSize - prefix);
   const blockSize = BigInt(1) << hostBits;
   const start = (parsedIp.value >> hostBits) << hostBits;

--- a/src/utils/rule-search.ts
+++ b/src/utils/rule-search.ts
@@ -85,7 +85,6 @@ export const normalizeDomain = (value: string) => {
   return withoutPort
     .replace(/^\*\./, "")
     .replace(/^\+\./, "")
-    .replace(/^www\d*\./, "")
     .replace(/^\./, "")
     .replace(/\.$/, "");
 };

--- a/src/utils/rule-search.ts
+++ b/src/utils/rule-search.ts
@@ -70,12 +70,15 @@ const getExplicitRulePayload = (payload: string, ruleTypes: Set<string>) => {
 export const normalizeDomain = (value: string) => {
   const trimmed = value.trim().toLowerCase();
   const rawHost = (() => {
-    try {
-      return new URL(trimmed).hostname;
-    } catch {
-      const withoutScheme = trimmed.replace(/^[a-z][a-z\d+.-]*:\/\//, "");
-      return withoutScheme.split(/[/?#]/)[0] ?? "";
+    if (trimmed.includes("://")) {
+      try {
+        return new URL(trimmed).hostname;
+      } catch {
+        // fall through
+      }
     }
+    const withoutScheme = trimmed.replace(/^[a-z][a-z\d+.-]*:\/\//, "");
+    return withoutScheme.split(/[/?#]/)[0] ?? "";
   })();
   const withoutPort = rawHost.replace(/:\d+$/, "");
 

--- a/src/utils/rule-search.ts
+++ b/src/utils/rule-search.ts
@@ -30,7 +30,7 @@ const DOMAIN_RULE_TYPES = new Set([
   "GEOSITE",
 ]);
 
-const CIDR_RULE_TYPES = new Set(["IP-CIDR", "SRC-IP-CIDR"]);
+const CIDR_RULE_TYPES = new Set(["IP-CIDR", "IP-CIDR6", "SRC-IP-CIDR"]);
 
 const normalizeRuleType = (type: string) => {
   const ruleTypeMap: Record<string, string> = {
@@ -52,6 +52,20 @@ const splitRuleParts = (payload: string) =>
     .split(",")
     .map((part) => part.trim())
     .filter(Boolean);
+
+const getExplicitRulePayload = (payload: string, ruleTypes: Set<string>) => {
+  const parts = splitRuleParts(payload);
+  const explicitType = parts[0] ? normalizeRuleType(parts[0]) : undefined;
+
+  if (!explicitType || !ruleTypes.has(explicitType)) {
+    return null;
+  }
+
+  const source = parts[1] ?? "";
+  if (!source) return null;
+
+  return { type: explicitType, source };
+};
 
 export const normalizeDomain = (value: string) => {
   const trimmed = value.trim().toLowerCase();
@@ -75,11 +89,20 @@ export const normalizeDomain = (value: string) => {
 
 const getDomainSearchPayload = (rule: SearchableRule, payload: string) => {
   if (!payload) return null;
-  const ruleType = normalizeRuleType(rule.type);
+  const explicitPayload = getExplicitRulePayload(payload, DOMAIN_RULE_TYPES);
+
+  if (explicitPayload) {
+    return {
+      type: explicitPayload.type,
+      value: normalizeDomain(explicitPayload.source),
+    };
+  }
 
   if (rule.behavior && rule.behavior.toLowerCase() !== "domain") {
     return null;
   }
+
+  const ruleType = normalizeRuleType(rule.type);
   if (!rule.behavior && !DOMAIN_RULE_TYPES.has(ruleType)) {
     return null;
   }
@@ -207,30 +230,22 @@ const rangesOverlap = (left: IpRange, right: IpRange) =>
   right.start <= left.end;
 
 const getCidrSearchPayload = (rule: SearchableRule, payload: string) => {
-  const parts = splitRuleParts(payload);
-  const explicitType = parts[0] ? normalizeRuleType(parts[0]) : undefined;
-  const hasExplicitType = explicitType
-    ? CIDR_RULE_TYPES.has(explicitType)
-    : false;
-  const source = (hasExplicitType ? parts[1] : payload) ?? "";
-  const ruleType =
-    hasExplicitType && explicitType
-      ? explicitType
-      : normalizeRuleType(rule.type);
+  const explicitPayload = getExplicitRulePayload(payload, CIDR_RULE_TYPES);
+  if (explicitPayload) {
+    return explicitPayload.source;
+  }
 
-  if (!source) return null;
-  if (
-    !hasExplicitType &&
-    rule.behavior &&
-    rule.behavior.toLowerCase() !== "ipcidr"
-  ) {
+  if (!payload) return null;
+  if (rule.behavior && rule.behavior.toLowerCase() !== "ipcidr") {
     return null;
   }
+
+  const ruleType = normalizeRuleType(rule.type);
   if (!rule.behavior && !CIDR_RULE_TYPES.has(ruleType)) {
     return null;
   }
 
-  return source;
+  return payload;
 };
 
 const cidrMatches = (

--- a/src/utils/rule-search.ts
+++ b/src/utils/rule-search.ts
@@ -1,0 +1,275 @@
+type SearchableRule = {
+  type: string;
+  behavior?: string;
+};
+
+type IpRange = {
+  version: 4 | 6;
+  start: bigint;
+  end: bigint;
+};
+
+export type RuleSearchMode = "domain" | "cidr";
+
+export type RuleSearchState = {
+  mode: RuleSearchMode;
+  text: string;
+};
+
+export const EMPTY_RULE_SEARCH: RuleSearchState = {
+  mode: "domain",
+  text: "",
+};
+
+const DOMAIN_RULE_TYPES = new Set([
+  "DOMAIN",
+  "DOMAIN-SUFFIX",
+  "DOMAIN-KEYWORD",
+  "DOMAIN-REGEX",
+  "DOMAIN-WILDCARD",
+  "GEOSITE",
+]);
+
+const CIDR_RULE_TYPES = new Set(["IP-CIDR", "SRC-IP-CIDR"]);
+
+const normalizeRuleType = (type: string) => {
+  const ruleTypeMap: Record<string, string> = {
+    Domain: "DOMAIN",
+    DomainSuffix: "DOMAIN-SUFFIX",
+    DomainKeyword: "DOMAIN-KEYWORD",
+    DomainRegex: "DOMAIN-REGEX",
+    DomainWildcard: "DOMAIN-WILDCARD",
+    GeoSite: "GEOSITE",
+    IPCIDR: "IP-CIDR",
+    SrcIPCIDR: "SRC-IP-CIDR",
+  };
+
+  return ruleTypeMap[type] ?? type.toUpperCase();
+};
+
+const splitRuleParts = (payload: string) =>
+  payload
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+export const normalizeDomain = (value: string) => {
+  const trimmed = value.trim().toLowerCase();
+  const rawHost = (() => {
+    try {
+      return new URL(trimmed).hostname;
+    } catch {
+      const withoutScheme = trimmed.replace(/^[a-z][a-z\d+.-]*:\/\//, "");
+      return withoutScheme.split(/[/?#]/)[0] ?? "";
+    }
+  })();
+  const withoutPort = rawHost.replace(/:\d+$/, "");
+
+  return withoutPort
+    .replace(/^\*\./, "")
+    .replace(/^\+\./, "")
+    .replace(/^www\d*\./, "")
+    .replace(/^\./, "")
+    .replace(/\.$/, "");
+};
+
+const getDomainSearchPayload = (rule: SearchableRule, payload: string) => {
+  if (!payload) return null;
+  const ruleType = normalizeRuleType(rule.type);
+
+  if (rule.behavior && rule.behavior.toLowerCase() !== "domain") {
+    return null;
+  }
+  if (!rule.behavior && !DOMAIN_RULE_TYPES.has(ruleType)) {
+    return null;
+  }
+
+  return {
+    type: ruleType,
+    value: normalizeDomain(payload),
+  };
+};
+
+const domainMatches = (
+  rule: SearchableRule,
+  payload: string,
+  normalizedQuery: string,
+) => {
+  if (!normalizedQuery) return true;
+
+  const searchPayload = getDomainSearchPayload(rule, payload);
+  if (!searchPayload?.value) return false;
+
+  const { type, value } = searchPayload;
+
+  if (type === "DOMAIN-KEYWORD") {
+    return normalizedQuery.includes(value) || value.includes(normalizedQuery);
+  }
+
+  if (!normalizedQuery.includes(".")) {
+    return value.includes(normalizedQuery);
+  }
+
+  if (type === "DOMAIN") {
+    return value === normalizedQuery;
+  }
+
+  return (
+    value === normalizedQuery ||
+    normalizedQuery.endsWith(`.${value}`) ||
+    value.endsWith(`.${normalizedQuery}`)
+  );
+};
+
+const parseIpv4 = (value: string) => {
+  const parts = value.split(".");
+  if (parts.length !== 4) return null;
+
+  return parts.reduce<bigint | null>((acc, part) => {
+    if (acc === null || !/^\d+$/.test(part)) return null;
+    const byte = Number(part);
+    if (byte < 0 || byte > 255) return null;
+    return (acc << BigInt(8)) + BigInt(byte);
+  }, BigInt(0));
+};
+
+const parseIpv6 = (value: string) => {
+  const scopedValue = value
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "")
+    .split("%")[0];
+  if (!scopedValue || scopedValue.split("::").length > 2) return null;
+
+  let normalizedValue = scopedValue;
+  if (normalizedValue.includes(".")) {
+    const lastColonIndex = normalizedValue.lastIndexOf(":");
+    const ipv4 = parseIpv4(normalizedValue.slice(lastColonIndex + 1));
+    if (ipv4 === null) return null;
+
+    const high = Number((ipv4 >> BigInt(16)) & BigInt(0xffff)).toString(16);
+    const low = Number(ipv4 & BigInt(0xffff)).toString(16);
+    normalizedValue = `${normalizedValue.slice(0, lastColonIndex)}:${high}:${low}`;
+  }
+
+  const [left = "", right = ""] = normalizedValue.split("::");
+  const leftParts = left ? left.split(":") : [];
+  const rightParts = right ? right.split(":") : [];
+  const fillCount = 8 - leftParts.length - rightParts.length;
+  if (fillCount < 0 || (!normalizedValue.includes("::") && fillCount !== 0)) {
+    return null;
+  }
+
+  const parts = [
+    ...leftParts,
+    ...Array<string>(fillCount).fill("0"),
+    ...rightParts,
+  ];
+
+  return parts.reduce<bigint | null>((acc, part) => {
+    if (acc === null || !/^[\da-f]{1,4}$/.test(part)) return null;
+    return (acc << BigInt(16)) + BigInt(parseInt(part, 16));
+  }, BigInt(0));
+};
+
+const parseIpValue = (value: string) => {
+  if (value.includes(":")) {
+    const parsed = parseIpv6(value);
+    return parsed === null ? null : { version: 6 as const, value: parsed };
+  }
+
+  const parsed = parseIpv4(value);
+  return parsed === null ? null : { version: 4 as const, value: parsed };
+};
+
+const parseCidrRange = (value: string): IpRange | null => {
+  const [address = "", prefixText] = value.trim().split("/");
+  const parsedIp = parseIpValue(address);
+  if (!parsedIp) return null;
+
+  const bitSize = parsedIp.version === 4 ? 32 : 128;
+  const prefix = prefixText === undefined ? bitSize : Number(prefixText);
+  if (!Number.isInteger(prefix) || prefix < 0 || prefix > bitSize) return null;
+
+  const hostBits = BigInt(bitSize - prefix);
+  const blockSize = BigInt(1) << hostBits;
+  const start = (parsedIp.value >> hostBits) << hostBits;
+
+  return {
+    version: parsedIp.version,
+    start,
+    end: start + blockSize - BigInt(1),
+  };
+};
+
+const rangesOverlap = (left: IpRange, right: IpRange) =>
+  left.version === right.version &&
+  left.start <= right.end &&
+  right.start <= left.end;
+
+const getCidrSearchPayload = (rule: SearchableRule, payload: string) => {
+  const parts = splitRuleParts(payload);
+  const explicitType = parts[0] ? normalizeRuleType(parts[0]) : undefined;
+  const hasExplicitType = explicitType
+    ? CIDR_RULE_TYPES.has(explicitType)
+    : false;
+  const source = (hasExplicitType ? parts[1] : payload) ?? "";
+  const ruleType =
+    hasExplicitType && explicitType
+      ? explicitType
+      : normalizeRuleType(rule.type);
+
+  if (!source) return null;
+  if (
+    !hasExplicitType &&
+    rule.behavior &&
+    rule.behavior.toLowerCase() !== "ipcidr"
+  ) {
+    return null;
+  }
+  if (!rule.behavior && !CIDR_RULE_TYPES.has(ruleType)) {
+    return null;
+  }
+
+  return source;
+};
+
+const cidrMatches = (
+  rule: SearchableRule,
+  payload: string,
+  normalizedQuery: string,
+  queryRange: IpRange | null,
+) => {
+  if (!normalizedQuery) return true;
+  const cidrPayload = getCidrSearchPayload(rule, payload);
+  if (!cidrPayload) return false;
+
+  const payloadRange = parseCidrRange(cidrPayload);
+  if (!queryRange || !payloadRange) {
+    return cidrPayload.toLowerCase().includes(normalizedQuery);
+  }
+
+  return rangesOverlap(queryRange, payloadRange);
+};
+
+export const createRuleSearchMatcher = (search: RuleSearchState) => {
+  if (!search.text) return () => true;
+
+  if (search.mode === "domain") {
+    const normalizedQuery = normalizeDomain(search.text);
+    return (rule: SearchableRule, payload: string) =>
+      domainMatches(rule, payload, normalizedQuery);
+  }
+
+  const normalizedQuery = search.text.trim().toLowerCase();
+  const queryRange = parseCidrRange(normalizedQuery);
+  return (rule: SearchableRule, payload: string) =>
+    cidrMatches(rule, payload, normalizedQuery, queryRange);
+};
+
+export const ruleMatchesSearch = (
+  rule: SearchableRule,
+  payload: string,
+  search: RuleSearchState,
+) => {
+  return createRuleSearchMatcher(search)(rule, payload);
+};


### PR DESCRIPTION
## 变更概述
- 新增规则页专用搜索框，支持 Domain 和 CIDR 两种搜索模式
- 支持规则组 payload 内容搜索，包括 domain/ipcidr/classical provider 中的显式规则
- 增加搜索状态展示和搜索中加载提示
- 优化展开/收起、轮询元数据更新和订阅切换时的规则状态处理

## 主要改动
- 新增 `src/components/rule/rule-search-box.tsx`
- 新增 `src/utils/rule-search.ts`，集中处理域名规范化、CIDR 解析和规则匹配
- 更新 `src/pages/rules.tsx`，替换通用搜索框并展示搜索统计
- 更新 `src/components/rule/rule-item.tsx`，避免开关点击触发展开，并使用当前 store 规则状态渲染
- 更新 `src/stores/rulesStateStore.ts`，保留已加载 provider payload，同时避免 volatile 元数据更新清空展开状态
- 补充中英俄波斯语文案

## 验证情况
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint src/pages/rules.tsx src/components/rule/rule-item.tsx src/components/rule/rule-search-box.tsx src/stores/rulesStateStore.ts src/utils/rule-search.ts --max-warnings=0`
- `git diff --check`
- `npx gitnexus detect-changes --scope unstaged`

## 备注
- 当前本地 `gh auth status` 显示 token invalid，因此本 PR 通过 GitHub connector 创建。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增规则搜索组件（域名 / CIDR 模式），支持即时提交、清除与模式切换，搜索界面显示匹配/总数并在搜索时展示加载状态。

* **国际化**
  * 为搜索相关文案新增中/英/俄/波斯文翻译条目。

* **改进**
  * 规则列表与条目显示改为基于集中状态，统一展开/折叠、禁用样式、命中/未命中指示及计数/时间显示；改进匹配算法以支持域名规范化和 CIDR 范围匹配，保留展开状态的稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->