### PR TITLE
feat(rule-search): add content fuzzy search mode

### DIFF
--- a/src/components/rule/rule-search-box.tsx
+++ b/src/components/rule/rule-search-box.tsx
@@ -43,11 +43,7 @@ export const RuleSearchBox = ({ onSearch }: Props) => {
       spellCheck="false"
       value={text}
       placeholder={
-        mode === "content"
-          ? t("common.search.contentPlaceholder")
-          : mode === "domain"
-            ? t("common.search.domainPlaceholder")
-            : t("common.search.cidrPlaceholder")
+        t(`common.search.${mode}Placeholder`)
       }
       sx={[
         {

--- a/src/components/rule/rule-search-box.tsx
+++ b/src/components/rule/rule-search-box.tsx
@@ -102,8 +102,8 @@ export const RuleSearchBox = ({ onSearch }: Props) => {
                     <LanguageRounded fontSize="small" />
                   </Tooltip>
                 </ToggleButton>
-                <ToggleButton value="cidr" aria-label="CIDR">
-                  <Tooltip title="CIDR">
+                <ToggleButton value="cidr" aria-label={t("common.search.cidr")}>
+                  <Tooltip title={t("common.search.cidr")}>
                     <DnsRounded fontSize="small" />
                   </Tooltip>
                 </ToggleButton>

--- a/src/components/rule/rule-search-box.tsx
+++ b/src/components/rule/rule-search-box.tsx
@@ -1,3 +1,4 @@
+import ArticleRounded from "@mui/icons-material/ArticleRounded";
 import ClearRounded from "@mui/icons-material/ClearRounded";
 import DnsRounded from "@mui/icons-material/DnsRounded";
 import LanguageRounded from "@mui/icons-material/LanguageRounded";
@@ -23,7 +24,7 @@ type Props = {
 export const RuleSearchBox = ({ onSearch }: Props) => {
   const { t } = useTranslation();
   const [text, setText] = useState("");
-  const [mode, setMode] = useState<RuleSearchMode>("domain");
+  const [mode, setMode] = useState<RuleSearchMode>("content");
 
   const submitSearch = useCallback(
     (nextMode = mode, nextText = text) => {
@@ -42,9 +43,11 @@ export const RuleSearchBox = ({ onSearch }: Props) => {
       spellCheck="false"
       value={text}
       placeholder={
-        mode === "domain"
-          ? t("common.search.domainPlaceholder")
-          : t("common.search.cidrPlaceholder")
+        mode === "content"
+          ? t("common.search.contentPlaceholder")
+          : mode === "domain"
+            ? t("common.search.domainPlaceholder")
+            : t("common.search.cidrPlaceholder")
       }
       sx={[
         {
@@ -85,6 +88,13 @@ export const RuleSearchBox = ({ onSearch }: Props) => {
                     py: 0,
                   },
                 }}>
+                <ToggleButton
+                  value="content"
+                  aria-label={t("common.search.content")}>
+                  <Tooltip title={t("common.search.content")}>
+                    <ArticleRounded fontSize="small" />
+                  </Tooltip>
+                </ToggleButton>
                 <ToggleButton
                   value="domain"
                   aria-label={t("common.search.domain")}>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -84,6 +84,7 @@
       "contentPlaceholder": "Search rule content",
       "domain": "Domain",
       "domainPlaceholder": "Search domain, e.g. google.com",
+      "cidr": "CIDR",
       "cidrPlaceholder": "Search IP or CIDR, e.g. 8.8.8.8 or 8.8.8.0/24",
       "rulesTotal": "{{count}} rules",
       "rulesMatched": "{{mode}}: {{text}} · {{groups}} groups / {{items}} entries",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -80,6 +80,8 @@
     "search": {
       "filter": "Filter",
       "filterConditions": "Filter conditions",
+      "content": "Content",
+      "contentPlaceholder": "Search rule content",
       "domain": "Domain",
       "domainPlaceholder": "Search domain, e.g. google.com",
       "cidrPlaceholder": "Search IP or CIDR, e.g. 8.8.8.8 or 8.8.8.0/24",

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -84,6 +84,7 @@
       "contentPlaceholder": "جستجوی محتوای قاعده",
       "domain": "دامنه",
       "domainPlaceholder": "جستجوی دامنه، مانند google.com",
+      "cidr": "CIDR",
       "cidrPlaceholder": "جستجوی IP یا CIDR، مانند 8.8.8.8 یا 8.8.8.0/24",
       "rulesTotal": "{{count}} قاعده",
       "rulesMatched": "{{mode}}: {{text}} · {{groups}} گروه / {{items}} مورد",

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -80,6 +80,8 @@
     "search": {
       "filter": "فیلتر",
       "filterConditions": "شرایط فیلتر",
+      "content": "محتوا",
+      "contentPlaceholder": "جستجوی محتوای قاعده",
       "domain": "دامنه",
       "domainPlaceholder": "جستجوی دامنه، مانند google.com",
       "cidrPlaceholder": "جستجوی IP یا CIDR، مانند 8.8.8.8 یا 8.8.8.0/24",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -80,6 +80,8 @@
     "search": {
       "filter": "Фильтр",
       "filterConditions": "Условия фильтрации",
+      "content": "Содержимое",
+      "contentPlaceholder": "Поиск по содержимому правила",
       "domain": "Домен",
       "domainPlaceholder": "Поиск домена, например google.com",
       "cidrPlaceholder": "Поиск IP или CIDR, например 8.8.8.8 или 8.8.8.0/24",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -84,6 +84,7 @@
       "contentPlaceholder": "Поиск по содержимому правила",
       "domain": "Домен",
       "domainPlaceholder": "Поиск домена, например google.com",
+      "cidr": "CIDR",
       "cidrPlaceholder": "Поиск IP или CIDR, например 8.8.8.8 или 8.8.8.0/24",
       "rulesTotal": "Всего правил: {{count}}",
       "rulesMatched": "{{mode}}: {{text}} · {{groups}} групп / {{items}} записей",

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -84,6 +84,7 @@
       "contentPlaceholder": "搜索规则内容",
       "domain": "域名",
       "domainPlaceholder": "搜索域名，例如 google.com",
+      "cidr": "CIDR",
       "cidrPlaceholder": "搜索 IP 或 CIDR，例如 8.8.8.8 或 8.8.8.0/24",
       "rulesTotal": "共 {{count}} 条规则",
       "rulesMatched": "{{mode}}：{{text}} · 命中 {{groups}} 组 / {{items}} 条",

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -80,6 +80,8 @@
     "search": {
       "filter": "过滤节点",
       "filterConditions": "过滤条件",
+      "content": "内容",
+      "contentPlaceholder": "搜索规则内容",
       "domain": "域名",
       "domainPlaceholder": "搜索域名，例如 google.com",
       "cidrPlaceholder": "搜索 IP 或 CIDR，例如 8.8.8.8 或 8.8.8.0/24",

--- a/src/pages/rules.tsx
+++ b/src/pages/rules.tsx
@@ -90,8 +90,14 @@ const RulesPage = () => {
     }, 0);
 
     return t("common.search.rulesMatched", {
-      mode: search.mode === "domain" ? t("common.search.domain") : "CIDR",
-      text: normalizeDomain(search.text),
+      mode:
+        search.mode === "content"
+          ? t("common.search.content")
+          : search.mode === "domain"
+            ? t("common.search.domain")
+            : "CIDR",
+      text:
+        search.mode === "domain" ? normalizeDomain(search.text) : search.text,
       groups: filterRules.length,
       items: matchedItems,
     });

--- a/src/pages/rules.tsx
+++ b/src/pages/rules.tsx
@@ -90,12 +90,7 @@ const RulesPage = () => {
     }, 0);
 
     return t("common.search.rulesMatched", {
-      mode:
-        search.mode === "content"
-          ? t("common.search.content")
-          : search.mode === "domain"
-            ? t("common.search.domain")
-            : t("common.search.cidr"),
+      mode: t(`common.search.${search.mode}`),
       text:
         search.mode === "domain" ? normalizeDomain(search.text) : search.text,
       groups: filterRules.length,

--- a/src/pages/rules.tsx
+++ b/src/pages/rules.tsx
@@ -95,7 +95,7 @@ const RulesPage = () => {
           ? t("common.search.content")
           : search.mode === "domain"
             ? t("common.search.domain")
-            : "CIDR",
+            : t("common.search.cidr"),
       text:
         search.mode === "domain" ? normalizeDomain(search.text) : search.text,
       groups: filterRules.length,

--- a/src/utils/rule-search.ts
+++ b/src/utils/rule-search.ts
@@ -9,7 +9,7 @@ type IpRange = {
   end: bigint;
 };
 
-export type RuleSearchMode = "domain" | "cidr";
+export type RuleSearchMode = "content" | "domain" | "cidr";
 
 export type RuleSearchState = {
   mode: RuleSearchMode;
@@ -17,7 +17,7 @@ export type RuleSearchState = {
 };
 
 export const EMPTY_RULE_SEARCH: RuleSearchState = {
-  mode: "domain",
+  mode: "content",
   text: "",
 };
 
@@ -272,6 +272,12 @@ const cidrMatches = (
 
 export const createRuleSearchMatcher = (search: RuleSearchState) => {
   if (!search.text) return () => true;
+
+  if (search.mode === "content") {
+    const normalizedQuery = search.text.trim().toLowerCase();
+    return (_rule: SearchableRule, payload: string) =>
+      payload.toLowerCase().includes(normalizedQuery);
+  }
 
   if (search.mode === "domain") {
     const normalizedQuery = normalizeDomain(search.text);

--- a/src/utils/rule-search.ts
+++ b/src/utils/rule-search.ts
@@ -53,6 +53,17 @@ const splitRuleParts = (payload: string) =>
     .map((part) => part.trim())
     .filter(Boolean);
 
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const createFuzzyMatcher = (query: string) => {
+  const normalizedQuery = query.trim();
+  if (!normalizedQuery) return () => true;
+
+  const matcher = new RegExp(escapeRegExp(normalizedQuery), "i");
+  return (value: string) => matcher.test(value);
+};
+
 const getExplicitRulePayload = (payload: string, ruleTypes: Set<string>) => {
   const parts = splitRuleParts(payload);
   const explicitType = parts[0] ? normalizeRuleType(parts[0]) : undefined;
@@ -274,9 +285,9 @@ export const createRuleSearchMatcher = (search: RuleSearchState) => {
   if (!search.text) return () => true;
 
   if (search.mode === "content") {
-    const normalizedQuery = search.text.trim().toLowerCase();
+    const matchesContent = createFuzzyMatcher(search.text);
     return (_rule: SearchableRule, payload: string) =>
-      !!payload && payload.toLowerCase().includes(normalizedQuery);
+      !!payload && matchesContent(payload);
   }
 
   if (search.mode === "domain") {

--- a/src/utils/rule-search.ts
+++ b/src/utils/rule-search.ts
@@ -276,7 +276,7 @@ export const createRuleSearchMatcher = (search: RuleSearchState) => {
   if (search.mode === "content") {
     const normalizedQuery = search.text.trim().toLowerCase();
     return (_rule: SearchableRule, payload: string) =>
-      payload.toLowerCase().includes(normalizedQuery);
+      !!payload && payload.toLowerCase().includes(normalizedQuery);
   }
 
   if (search.mode === "domain") {


### PR DESCRIPTION
## 变更概述
- 为规则搜索新增“内容”模式，作为默认搜索模式
- 内容模式按规则原始 payload 做大小写不敏感的模糊匹配
- 保留 Domain 和 CIDR 专用搜索模式，用于语义化域名和网段匹配

## 主要改动
- `src/utils/rule-search.ts`：扩展 `RuleSearchMode`，新增 content matcher
- `src/components/rule/rule-search-box.tsx`：新增内容搜索模式按钮，并将默认模式改为内容搜索
- `src/pages/rules.tsx`：搜索状态展示支持内容模式
- `src/locales/*.json`：补充内容搜索模式文案

## 行为说明
- 普通规则：内容模式只匹配 `payload` 字段
- 规则组：内容模式匹配 `payloadContent` 中的原始规则行
- Domain / CIDR 模式仍保持原有专用匹配行为

## 验证情况
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint src/pages/rules.tsx src/components/rule/rule-search-box.tsx src/utils/rule-search.ts --max-warnings=0`
- `git diff --check origin/dev...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增“内容”搜索模式并设为默认，支持对规则文本的大小写无关子串匹配；搜索栏加入“内容”切换按钮，切换时提示与占位符根据当前模式通过国际化更新；域名模式与 CIDR 模式的匹配行为保持不变。
* **本地化**
  * 为英文、波斯文、俄文和中文添加“内容”标签及对应占位符翻译。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->