### PR TITLE
feat(connections): add multi-field connection filtering

### DIFF
--- a/src/components/connection/connection-filter-box.tsx
+++ b/src/components/connection/connection-filter-box.tsx
@@ -117,6 +117,7 @@ const CONNECTION_FILTER_FIELDS: ConnectionFilterFieldConfig[] = [
     field: "chains",
     labelKey: "pages.connections.columns.chains",
     getValues: ({ chains }) => {
+      if (!chains?.length) return [];
       const formatChains = [...chains].reverse().join(" / ");
       return compactValues([formatChains]);
     },

--- a/src/components/connection/connection-filter-box.tsx
+++ b/src/components/connection/connection-filter-box.tsx
@@ -189,13 +189,17 @@ export const createConnectionFilterMatcher = (
 type Props = {
   connections: IClosedConnectionItem[];
   filters: ConnectionFilter[];
+  hostSearch: string;
   onChange: (filters: ConnectionFilter[]) => void;
+  onHostSearchChange: (value: string) => void;
 };
 
 export const ConnectionFilterBox = ({
   connections,
   filters,
+  hostSearch,
   onChange,
+  onHostSearchChange,
 }: Props) => {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
@@ -298,13 +302,19 @@ export const ConnectionFilterBox = ({
     [filters, onChange],
   );
 
-  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+  const handleValueSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
     resetValueListScroll();
     setValueSearch(event.target.value);
   };
 
   const handleInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (event.key !== "Backspace" || filters.length === 0) return;
+    if (
+      event.key !== "Backspace" ||
+      hostSearch.length > 0 ||
+      filters.length === 0
+    ) {
+      return;
+    }
     event.preventDefault();
     onChange(filters.slice(0, -1));
   };
@@ -313,6 +323,7 @@ export const ConnectionFilterBox = ({
     event.preventDefault();
     event.stopPropagation();
     onChange([]);
+    onHostSearchChange("");
   };
 
   return (
@@ -320,7 +331,6 @@ export const ConnectionFilterBox = ({
       <Box sx={{ minWidth: 0, flex: 1 }}>
         <Box
           ref={anchorRef}
-          onClick={() => setOpen(true)}
           sx={[
             {
               height: 32,
@@ -347,7 +357,19 @@ export const ConnectionFilterBox = ({
             }),
           ]}>
           <InputAdornment position="start" sx={{ mr: 0, flexShrink: 0 }}>
-            <FilterAltRounded fontSize="small" color="action" />
+            <Tooltip title={t("pages.connections.filters.placeholder")}>
+              <IconButton
+                size="small"
+                color={open ? "primary" : "default"}
+                sx={{ p: 0.25 }}
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  setOpen(true);
+                }}>
+                <FilterAltRounded fontSize="small" />
+              </IconButton>
+            </Tooltip>
           </InputAdornment>
           <Box
             sx={{
@@ -391,10 +413,12 @@ export const ConnectionFilterBox = ({
             <InputBase
               placeholder={
                 filters.length === 0
-                  ? t("pages.connections.filters.placeholder")
+                  ? t("pages.connections.filters.hostPlaceholder")
                   : undefined
               }
-              onFocus={() => setOpen(true)}
+              value={hostSearch}
+              readOnly={open}
+              onChange={(event) => onHostSearchChange(event.target.value)}
               onKeyDown={handleInputKeyDown}
               sx={{
                 minWidth: filters.length > 0 ? 64 : 120,
@@ -407,7 +431,7 @@ export const ConnectionFilterBox = ({
               }}
             />
           </Box>
-          {filters.length > 0 && (
+          {(filters.length > 0 || hostSearch.length > 0) && (
             <Tooltip title={t("common.actions.clear")}>
               <IconButton
                 size="small"
@@ -521,7 +545,7 @@ export const ConnectionFilterBox = ({
                     <InputBase
                       value={valueSearch}
                       placeholder={t("common.search.filter")}
-                      onChange={handleInputChange}
+                      onChange={handleValueSearchChange}
                       sx={{
                         minWidth: 0,
                         flex: 1,

--- a/src/components/connection/connection-filter-box.tsx
+++ b/src/components/connection/connection-filter-box.tsx
@@ -312,7 +312,7 @@ export const ConnectionFilterBox = ({
     });
 
     return nextMap;
-  }, [connections, filters, hostSearch]);
+  }, [connections, filters, hostSearch, open]);
 
   const activeFieldValues = fieldValuesMap.get(activeField) ?? EMPTY_VALUES;
 

--- a/src/components/connection/connection-filter-box.tsx
+++ b/src/components/connection/connection-filter-box.tsx
@@ -365,6 +365,7 @@ export const ConnectionFilterBox = ({
                 onClick={(event) => {
                   event.preventDefault();
                   event.stopPropagation();
+                  onHostSearchChange("");
                   setOpen(true);
                 }}>
                 <FilterAltRounded fontSize="small" />

--- a/src/components/connection/connection-filter-box.tsx
+++ b/src/components/connection/connection-filter-box.tsx
@@ -54,6 +54,11 @@ type ConnectionFilterFieldConfig = {
   getValues: (connection: IClosedConnectionItem) => string[];
 };
 
+type CachedConnectionFilterValues = {
+  hostMatched: boolean;
+  valuesMap: Map<ConnectionFilterField, string[]>;
+};
+
 const compactValues = (values: Array<string | number | null | undefined>) => {
   const result: string[] = [];
   for (const value of values) {
@@ -227,27 +232,75 @@ export const ConnectionFilterBox = ({
 
   const fieldValuesMap = useMemo(() => {
     const normalizedHostSearch = hostSearch.trim().toLowerCase();
-    const nextMap = new Map<ConnectionFilterField, string[]>();
-    CONNECTION_FILTER_FIELDS.forEach(({ field, getValues }) => {
-      const matchesOtherFields = createConnectionFilterMatcher(filters, field);
-      const uniqueValues = new Set<string>();
+    // 先按字段聚合已选过滤值，避免为每个候选字段重复构建匹配器。
+    const filtersByField = new Map<ConnectionFilterField, Set<string>>();
+    filters.forEach(({ field, value }) => {
+      const values = filtersByField.get(field) ?? new Set<string>();
+      values.add(value.toLowerCase());
+      filtersByField.set(field, values);
+    });
 
-      connections.forEach((connection) => {
-        if (normalizedHostSearch) {
-          const host =
-            connection.metadata.host || connection.metadata.destinationIP || "";
-          if (!host.toLowerCase().includes(normalizedHostSearch)) return;
-        }
+    // 连接数据会随 WebSocket 高频刷新。这里按连接预计算所有字段值，
+    // 后续生成各字段候选列表时直接复用。
+    const cachedConnections = connections.map<CachedConnectionFilterValues>(
+      (connection) => {
+        const host =
+          connection.metadata.host || connection.metadata.destinationIP || "";
+        const valuesMap = new Map<ConnectionFilterField, string[]>();
 
-        if (!matchesOtherFields(connection)) return;
-        getValues(connection).forEach((value) => uniqueValues.add(value));
+        CONNECTION_FILTER_FIELDS.forEach(({ field, getValues }) => {
+          valuesMap.set(field, getValues(connection));
+        });
+
+        return {
+          hostMatched:
+            !normalizedHostSearch ||
+            host.toLowerCase().includes(normalizedHostSearch),
+          valuesMap,
+        };
+      },
+    );
+
+    const uniqueValuesByField = new Map<ConnectionFilterField, Set<string>>();
+    CONNECTION_FILTER_FIELDS.forEach(({ field }) => {
+      uniqueValuesByField.set(field, new Set<string>());
+    });
+
+    cachedConnections.forEach(({ hostMatched, valuesMap }) => {
+      if (!hostMatched) return;
+
+      // 某个字段的候选值应受其他已选字段限制，但不受自身限制。
+      // 记录当前连接未命中的字段，用于判断它还能贡献给哪些字段候选项。
+      const unmatchedFilterFields = new Set<ConnectionFilterField>();
+      for (const [filterField, expectedValues] of filtersByField) {
+        const values = valuesMap.get(filterField) ?? EMPTY_VALUES;
+        const matched = values.some((value) =>
+          expectedValues.has(value.toLowerCase()),
+        );
+        if (!matched) unmatchedFilterFields.add(filterField);
+      }
+
+      CONNECTION_FILTER_FIELDS.forEach(({ field }) => {
+        const canUseConnection =
+          unmatchedFilterFields.size === 0 ||
+          (unmatchedFilterFields.size === 1 &&
+            unmatchedFilterFields.has(field));
+
+        if (!canUseConnection) return;
+        const uniqueValues = uniqueValuesByField.get(field);
+        valuesMap.get(field)?.forEach((value) => uniqueValues?.add(value));
       });
+    });
 
+    const nextMap = new Map<ConnectionFilterField, string[]>();
+    CONNECTION_FILTER_FIELDS.forEach(({ field }) => {
+      const uniqueValues = uniqueValuesByField.get(field) ?? new Set<string>();
       const values = Array.from(uniqueValues).sort((left, right) =>
         left.localeCompare(right),
       );
       const signature = values.join("\u0000");
       const cached = fieldValuesCacheRef.current.get(field);
+      // 候选值未变化时复用数组引用，减少右侧列表重渲染并保留滚动位置。
       if (cached?.signature === signature) {
         nextMap.set(field, cached.values);
         return;

--- a/src/components/connection/connection-filter-box.tsx
+++ b/src/components/connection/connection-filter-box.tsx
@@ -410,7 +410,7 @@ export const ConnectionFilterBox = ({
             onClick={(event) => {
               event.preventDefault();
               event.stopPropagation();
-              setOpen(true);
+              setOpen(!open);
             }}>
             <FilterAltRounded fontSize="small" />
           </IconButton>

--- a/src/components/connection/connection-filter-box.tsx
+++ b/src/components/connection/connection-filter-box.tsx
@@ -205,7 +205,7 @@ export const ConnectionFilterBox = ({
   const [open, setOpen] = useState(false);
   const [activeField, setActiveField] = useState<ConnectionFilterField>("host");
   const [valueSearch, setValueSearch] = useState("");
-  const anchorRef = useRef<HTMLDivElement | null>(null);
+  const filterButtonRef = useRef<HTMLButtonElement | null>(null);
   const valueListRef = useRef<HTMLDivElement | null>(null);
   const fieldValuesCacheRef = useRef(
     new Map<
@@ -226,12 +226,19 @@ export const ConnectionFilterBox = ({
   }, [t]);
 
   const fieldValuesMap = useMemo(() => {
+    const normalizedHostSearch = hostSearch.trim().toLowerCase();
     const nextMap = new Map<ConnectionFilterField, string[]>();
     CONNECTION_FILTER_FIELDS.forEach(({ field, getValues }) => {
       const matchesOtherFields = createConnectionFilterMatcher(filters, field);
       const uniqueValues = new Set<string>();
 
       connections.forEach((connection) => {
+        if (normalizedHostSearch) {
+          const host =
+            connection.metadata.host || connection.metadata.destinationIP || "";
+          if (!host.toLowerCase().includes(normalizedHostSearch)) return;
+        }
+
         if (!matchesOtherFields(connection)) return;
         getValues(connection).forEach((value) => uniqueValues.add(value));
       });
@@ -251,7 +258,7 @@ export const ConnectionFilterBox = ({
     });
 
     return nextMap;
-  }, [connections, filters]);
+  }, [connections, filters, hostSearch]);
 
   const activeFieldValues = fieldValuesMap.get(activeField) ?? EMPTY_VALUES;
 
@@ -328,14 +335,40 @@ export const ConnectionFilterBox = ({
 
   return (
     <ClickAwayListener onClickAway={() => setOpen(false)}>
-      <Box sx={{ minWidth: 0, flex: 1 }}>
+      <Box sx={{ minWidth: 0, flex: 1, display: "flex", gap: 0.5 }}>
+        <Tooltip title={t("pages.connections.filters.placeholder")}>
+          <IconButton
+            ref={filterButtonRef}
+            size="small"
+            color={open || filters.length > 0 ? "primary" : "default"}
+            sx={[
+              {
+                flexShrink: 0,
+                width: 32,
+                height: 32,
+                border: "1px solid",
+                borderColor: "divider",
+                borderRadius: 1,
+              },
+              ({ palette: { mode } }) => ({
+                ...(mode === "light" && { backgroundColor: "#fff" }),
+              }),
+            ]}
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              setOpen(true);
+            }}>
+            <FilterAltRounded fontSize="small" />
+          </IconButton>
+        </Tooltip>
         <Box
-          ref={anchorRef}
           sx={[
             {
               height: 32,
               width: "100%",
               minWidth: 0,
+              flex: 1,
               display: "flex",
               alignItems: "center",
               gap: 0.5,
@@ -357,20 +390,7 @@ export const ConnectionFilterBox = ({
             }),
           ]}>
           <InputAdornment position="start" sx={{ mr: 0, flexShrink: 0 }}>
-            <Tooltip title={t("pages.connections.filters.placeholder")}>
-              <IconButton
-                size="small"
-                color={open ? "primary" : "default"}
-                sx={{ p: 0.25 }}
-                onClick={(event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  onHostSearchChange("");
-                  setOpen(true);
-                }}>
-                <FilterAltRounded fontSize="small" />
-              </IconButton>
-            </Tooltip>
+            <SearchRounded fontSize="small" color="action" />
           </InputAdornment>
           <Box
             sx={{
@@ -418,8 +438,8 @@ export const ConnectionFilterBox = ({
                   : undefined
               }
               value={hostSearch}
-              readOnly={open}
               onChange={(event) => onHostSearchChange(event.target.value)}
+              onFocus={() => setOpen(false)}
               onKeyDown={handleInputKeyDown}
               sx={{
                 minWidth: filters.length > 0 ? 64 : 120,
@@ -447,7 +467,7 @@ export const ConnectionFilterBox = ({
 
         <Popper
           open={open}
-          anchorEl={anchorRef.current}
+          anchorEl={filterButtonRef.current}
           placement="bottom-start"
           sx={{ zIndex: (theme) => theme.zIndex.modal + 1 }}>
           <Paper elevation={6} sx={{ mt: 0.5 }}>
@@ -572,6 +592,7 @@ export const ConnectionFilterBox = ({
                 </Box>
                 <Box
                   ref={valueListRef}
+                  role="listbox"
                   sx={{
                     display: "flex",
                     flexDirection: "column",

--- a/src/components/connection/connection-filter-box.tsx
+++ b/src/components/connection/connection-filter-box.tsx
@@ -55,9 +55,12 @@ type ConnectionFilterFieldConfig = {
 };
 
 const compactValues = (values: Array<string | number | null | undefined>) => {
-  return values
-    .map((value) => String(value ?? "").trim())
-    .filter((value) => value.length > 0);
+  const result: string[] = [];
+  for (const value of values) {
+    const trimmed = String(value ?? "").trim();
+    if (trimmed.length > 0) result.push(trimmed);
+  }
+  return result;
 };
 
 const getFilterKey = ({ field, value }: ConnectionFilter) =>

--- a/src/components/connection/connection-filter-box.tsx
+++ b/src/components/connection/connection-filter-box.tsx
@@ -231,6 +231,7 @@ export const ConnectionFilterBox = ({
   }, [t]);
 
   const fieldValuesMap = useMemo(() => {
+    if (!open) return new Map<ConnectionFilterField, string[]>();
     const normalizedHostSearch = hostSearch.trim().toLowerCase();
     // 先按字段聚合已选过滤值，避免为每个候选字段重复构建匹配器。
     const filtersByField = new Map<ConnectionFilterField, Set<string>>();

--- a/src/components/connection/connection-filter-box.tsx
+++ b/src/components/connection/connection-filter-box.tsx
@@ -1,0 +1,625 @@
+import CloseRounded from "@mui/icons-material/CloseRounded";
+import FilterAltRounded from "@mui/icons-material/FilterAltRounded";
+import SearchRounded from "@mui/icons-material/SearchRounded";
+import {
+  Box,
+  Chip,
+  ClickAwayListener,
+  IconButton,
+  InputAdornment,
+  InputBase,
+  List,
+  ListItemButton,
+  ListItemText,
+  Paper,
+  Popper,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import {
+  ChangeEvent,
+  KeyboardEvent,
+  MouseEvent,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useTranslation } from "react-i18next";
+
+import { IClosedConnectionItem } from "@/hooks/use-connection-data";
+
+export type ConnectionFilterField =
+  | "host"
+  | "destinationIP"
+  | "destinationPort"
+  | "network"
+  | "type"
+  | "process"
+  | "rule"
+  | "chains"
+  | "sourceIP"
+  | "sourcePort"
+  | "remoteDestination"
+  | "inboundName";
+
+export type ConnectionFilter = {
+  field: ConnectionFilterField;
+  value: string;
+};
+
+type ConnectionFilterFieldConfig = {
+  field: ConnectionFilterField;
+  labelKey: string;
+  getValues: (connection: IClosedConnectionItem) => string[];
+};
+
+const compactValues = (values: Array<string | number | null | undefined>) => {
+  return values
+    .map((value) => String(value ?? "").trim())
+    .filter((value) => value.length > 0);
+};
+
+const getFilterKey = ({ field, value }: ConnectionFilter) =>
+  `${field}\u0000${value}`;
+
+const EMPTY_VALUES: string[] = [];
+
+const CONNECTION_FILTER_FIELDS: ConnectionFilterFieldConfig[] = [
+  {
+    field: "host",
+    labelKey: "common.fields.host",
+    getValues: ({ metadata }) => {
+      const host = metadata.host
+        ? `${metadata.host}:${metadata.destinationPort}`
+        : `${metadata.destinationIP}:${metadata.destinationPort}`;
+      return compactValues([host]);
+    },
+  },
+  {
+    field: "destinationIP",
+    labelKey: "pages.connections.filters.destinationIP",
+    getValues: ({ metadata }) => compactValues([metadata.destinationIP]),
+  },
+  {
+    field: "destinationPort",
+    labelKey: "pages.connections.filters.destinationPort",
+    getValues: ({ metadata }) => compactValues([metadata.destinationPort]),
+  },
+  {
+    field: "network",
+    labelKey: "pages.connections.filters.network",
+    getValues: ({ metadata }) => compactValues([metadata.network]),
+  },
+  {
+    field: "type",
+    labelKey: "common.fields.type",
+    getValues: ({ metadata }) => compactValues([metadata.type]),
+  },
+  {
+    field: "process",
+    labelKey: "common.fields.process",
+    getValues: ({ metadata }) =>
+      compactValues([metadata.process, metadata.processPath]),
+  },
+  {
+    field: "rule",
+    labelKey: "pages.connections.columns.rule",
+    getValues: ({ rule, rulePayload }) => {
+      const formatRule = rulePayload ? `${rule}(${rulePayload})` : rule;
+      return compactValues([formatRule]);
+    },
+  },
+  {
+    field: "chains",
+    labelKey: "pages.connections.columns.chains",
+    getValues: ({ chains }) => {
+      const formatChains = [...chains].reverse().join(" / ");
+      return compactValues([formatChains]);
+    },
+  },
+  {
+    field: "sourceIP",
+    labelKey: "pages.connections.filters.sourceIP",
+    getValues: ({ metadata }) => compactValues([metadata.sourceIP]),
+  },
+  {
+    field: "sourcePort",
+    labelKey: "pages.connections.filters.sourcePort",
+    getValues: ({ metadata }) => compactValues([metadata.sourcePort]),
+  },
+  {
+    field: "remoteDestination",
+    labelKey: "common.fields.destination",
+    getValues: ({ metadata }) =>
+      compactValues([metadata.remoteDestination, metadata.sniffHost]),
+  },
+  {
+    field: "inboundName",
+    labelKey: "pages.connections.filters.inbound",
+    getValues: ({ metadata }) =>
+      compactValues([metadata.inboundName, metadata.inboundUser]),
+  },
+];
+
+export const createConnectionFilterMatcher = (
+  filters: ConnectionFilter[],
+  excludedField?: ConnectionFilterField,
+) => {
+  const activeFilters = excludedField
+    ? filters.filter((filter) => filter.field !== excludedField)
+    : filters;
+
+  if (activeFilters.length === 0) return () => true;
+
+  const filterMap = new Map<ConnectionFilterField, Set<string>>();
+  activeFilters.forEach(({ field, value }) => {
+    const values = filterMap.get(field) ?? new Set<string>();
+    values.add(value.toLowerCase());
+    filterMap.set(field, values);
+  });
+
+  const matchers = Array.from(filterMap, ([field, values]) => {
+    const config = CONNECTION_FILTER_FIELDS.find(
+      (item) => item.field === field,
+    );
+    return config ? { getValues: config.getValues, values } : null;
+  }).filter(
+    (
+      item,
+    ): item is {
+      getValues: ConnectionFilterFieldConfig["getValues"];
+      values: Set<string>;
+    } => item !== null,
+  );
+
+  if (matchers.length === 0) return () => true;
+
+  return (connection: IClosedConnectionItem) => {
+    return matchers.every(({ getValues, values }) =>
+      getValues(connection).some((value) => values.has(value.toLowerCase())),
+    );
+  };
+};
+
+type Props = {
+  connections: IClosedConnectionItem[];
+  filters: ConnectionFilter[];
+  onChange: (filters: ConnectionFilter[]) => void;
+};
+
+export const ConnectionFilterBox = ({
+  connections,
+  filters,
+  onChange,
+}: Props) => {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const [activeField, setActiveField] = useState<ConnectionFilterField>("host");
+  const [valueSearch, setValueSearch] = useState("");
+  const anchorRef = useRef<HTMLDivElement | null>(null);
+  const valueListRef = useRef<HTMLDivElement | null>(null);
+  const fieldValuesCacheRef = useRef(
+    new Map<
+      ConnectionFilterField,
+      {
+        signature: string;
+        values: string[];
+      }
+    >(),
+  );
+  const fieldLabelMap = useMemo(() => {
+    return new Map(
+      CONNECTION_FILTER_FIELDS.map(({ field, labelKey }) => [
+        field,
+        t(labelKey),
+      ]),
+    );
+  }, [t]);
+
+  const fieldValuesMap = useMemo(() => {
+    const nextMap = new Map<ConnectionFilterField, string[]>();
+    CONNECTION_FILTER_FIELDS.forEach(({ field, getValues }) => {
+      const matchesOtherFields = createConnectionFilterMatcher(filters, field);
+      const uniqueValues = new Set<string>();
+
+      connections.forEach((connection) => {
+        if (!matchesOtherFields(connection)) return;
+        getValues(connection).forEach((value) => uniqueValues.add(value));
+      });
+
+      const values = Array.from(uniqueValues).sort((left, right) =>
+        left.localeCompare(right),
+      );
+      const signature = values.join("\u0000");
+      const cached = fieldValuesCacheRef.current.get(field);
+      if (cached?.signature === signature) {
+        nextMap.set(field, cached.values);
+        return;
+      }
+
+      fieldValuesCacheRef.current.set(field, { signature, values });
+      nextMap.set(field, values);
+    });
+
+    return nextMap;
+  }, [connections, filters]);
+
+  const activeFieldValues = fieldValuesMap.get(activeField) ?? EMPTY_VALUES;
+
+  const visibleValues = useMemo(() => {
+    const query = valueSearch.trim().toLowerCase();
+    const values = query
+      ? activeFieldValues.filter((value) => value.toLowerCase().includes(query))
+      : activeFieldValues;
+
+    return values;
+  }, [activeFieldValues, valueSearch]);
+
+  const selectedFilterSet = useMemo(() => {
+    return new Set(filters.map(getFilterKey));
+  }, [filters]);
+
+  const resetValueListScroll = useCallback(() => {
+    if (valueListRef.current) valueListRef.current.scrollTop = 0;
+  }, []);
+
+  const isSelected = useCallback(
+    (field: ConnectionFilterField, value: string) =>
+      selectedFilterSet.has(getFilterKey({ field, value })),
+    [selectedFilterSet],
+  );
+
+  const toggleFilter = useCallback(
+    (field: ConnectionFilterField, value: string) => {
+      const filter = { field, value };
+      if (isSelected(field, value)) {
+        onChange(
+          filters.filter((item) => getFilterKey(item) !== getFilterKey(filter)),
+        );
+        return;
+      }
+
+      onChange([...filters, filter]);
+    },
+    [filters, isSelected, onChange],
+  );
+
+  const removeFilter = useCallback(
+    (filter: ConnectionFilter) => {
+      onChange(
+        filters.filter((item) => getFilterKey(item) !== getFilterKey(filter)),
+      );
+    },
+    [filters, onChange],
+  );
+
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    resetValueListScroll();
+    setValueSearch(event.target.value);
+  };
+
+  const handleInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== "Backspace" || filters.length === 0) return;
+    event.preventDefault();
+    onChange(filters.slice(0, -1));
+  };
+
+  const handleClear = (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    onChange([]);
+  };
+
+  return (
+    <ClickAwayListener onClickAway={() => setOpen(false)}>
+      <Box sx={{ minWidth: 0, flex: 1 }}>
+        <Box
+          ref={anchorRef}
+          onClick={() => setOpen(true)}
+          sx={[
+            {
+              height: 32,
+              width: "100%",
+              minWidth: 0,
+              display: "flex",
+              alignItems: "center",
+              gap: 0.5,
+              px: 0.75,
+              py: 0.25,
+              border: "1px solid",
+              borderColor: "divider",
+              borderRadius: 1,
+              boxSizing: "border-box",
+              cursor: "text",
+              overflow: "hidden",
+              "&:focus-within": {
+                borderColor: "primary.main",
+                boxShadow: (theme) => `0 0 0 1px ${theme.palette.primary.main}`,
+              },
+            },
+            ({ palette: { mode } }) => ({
+              ...(mode === "light" && { backgroundColor: "#fff" }),
+            }),
+          ]}>
+          <InputAdornment position="start" sx={{ mr: 0, flexShrink: 0 }}>
+            <FilterAltRounded fontSize="small" color="action" />
+          </InputAdornment>
+          <Box
+            sx={{
+              minWidth: 0,
+              flex: 1,
+              display: "flex",
+              alignItems: "center",
+              flexWrap: "nowrap",
+              gap: 0.5,
+              height: 26,
+              overflowX: "auto",
+              overflowY: "hidden",
+              scrollbarWidth: "none",
+              "&::-webkit-scrollbar": {
+                display: "none",
+              },
+            }}>
+            {filters.map((filter) => (
+              <Chip
+                key={`${filter.field}\n${filter.value}`}
+                size="small"
+                label={`${fieldLabelMap.get(filter.field) ?? filter.field}: ${
+                  filter.value
+                }`}
+                onDelete={() => removeFilter(filter)}
+                sx={{
+                  flexShrink: 0,
+                  maxWidth: 160,
+                  height: 20,
+                  "& .MuiChip-label": {
+                    px: 0.625,
+                    fontSize: 11,
+                  },
+                  "& .MuiChip-deleteIcon": {
+                    fontSize: 15,
+                    mr: 0.125,
+                  },
+                }}
+              />
+            ))}
+            <InputBase
+              placeholder={
+                filters.length === 0
+                  ? t("pages.connections.filters.placeholder")
+                  : undefined
+              }
+              onFocus={() => setOpen(true)}
+              onKeyDown={handleInputKeyDown}
+              sx={{
+                minWidth: filters.length > 0 ? 64 : 120,
+                flex: filters.length > 0 ? "0 1 120px" : 1,
+                fontSize: 14,
+                "& input": {
+                  p: 0,
+                  height: 22,
+                },
+              }}
+            />
+          </Box>
+          {filters.length > 0 && (
+            <Tooltip title={t("common.actions.clear")}>
+              <IconButton
+                size="small"
+                color="primary"
+                sx={{ flexShrink: 0, p: 0.5 }}
+                onClick={handleClear}>
+                <CloseRounded fontSize="inherit" />
+              </IconButton>
+            </Tooltip>
+          )}
+        </Box>
+
+        <Popper
+          open={open}
+          anchorEl={anchorRef.current}
+          placement="bottom-start"
+          sx={{ zIndex: (theme) => theme.zIndex.modal + 1 }}>
+          <Paper elevation={6} sx={{ mt: 0.5 }}>
+            <Box
+              sx={(theme) => ({
+                display: "grid",
+                gridTemplateColumns: "152px minmax(0, 1fr)",
+                width: "min(720px, calc(100vw - 48px))",
+                height: 360,
+                border: `1px solid ${theme.palette.divider}`,
+                borderRadius: 1,
+                overflow: "hidden",
+              })}>
+              <List
+                dense
+                disablePadding
+                sx={(theme) => ({
+                  minHeight: 0,
+                  maxHeight: 360,
+                  overflowY: "auto",
+                  borderRight: `1px solid ${theme.palette.divider}`,
+                  bgcolor: theme.palette.action.hover,
+                })}>
+                {CONNECTION_FILTER_FIELDS.map(({ field }) => {
+                  const selected = field === activeField;
+                  const count = fieldValuesMap.get(field)?.length ?? 0;
+                  return (
+                    <ListItemButton
+                      key={field}
+                      selected={selected}
+                      disabled={count === 0}
+                      onClick={() => {
+                        resetValueListScroll();
+                        setValueSearch("");
+                        setActiveField(field);
+                      }}
+                      sx={{
+                        minHeight: 32,
+                        px: 1.25,
+                        py: 0.25,
+                      }}>
+                      <ListItemText
+                        primary={fieldLabelMap.get(field) ?? field}
+                        secondary={count}
+                        slotProps={{
+                          primary: {
+                            noWrap: true,
+                            variant: "caption",
+                            sx: {
+                              fontWeight: selected ? 700 : 500,
+                            },
+                          },
+                          secondary: {
+                            variant: "caption",
+                          },
+                        }}
+                      />
+                    </ListItemButton>
+                  );
+                })}
+              </List>
+              <Box
+                sx={{
+                  minWidth: 0,
+                  minHeight: 0,
+                  overflow: "hidden",
+                }}>
+                <Box
+                  sx={(theme) => ({
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 1,
+                    minHeight: 32,
+                    px: 1,
+                    borderBottom: `1px solid ${theme.palette.divider}`,
+                  })}>
+                  <Typography variant="caption" color="text.secondary" noWrap>
+                    {fieldLabelMap.get(activeField) ?? activeField}
+                  </Typography>
+                  <Box
+                    sx={(theme) => ({
+                      display: "flex",
+                      alignItems: "center",
+                      minWidth: 0,
+                      flex: 1,
+                      height: 24,
+                      px: 0.75,
+                      borderRadius: 0.75,
+                      bgcolor: theme.palette.action.hover,
+                    })}>
+                    <SearchRounded
+                      fontSize="inherit"
+                      color="action"
+                      sx={{ mr: 0.5 }}
+                    />
+                    <InputBase
+                      value={valueSearch}
+                      placeholder={t("common.search.filter")}
+                      onChange={handleInputChange}
+                      sx={{
+                        minWidth: 0,
+                        flex: 1,
+                        fontSize: 12,
+                        "& input": {
+                          p: 0,
+                          height: 20,
+                        },
+                      }}
+                    />
+                    {valueSearch && (
+                      <IconButton
+                        size="small"
+                        sx={{ p: 0.25 }}
+                        onClick={() => {
+                          resetValueListScroll();
+                          setValueSearch("");
+                        }}>
+                        <CloseRounded fontSize="inherit" />
+                      </IconButton>
+                    )}
+                  </Box>
+                </Box>
+                <Box
+                  ref={valueListRef}
+                  sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 0.25,
+                    p: 0.75,
+                    height: 327,
+                    overflowY: "auto",
+                    boxSizing: "border-box",
+                  }}>
+                  {visibleValues.length > 0 ? (
+                    visibleValues.map((value) => {
+                      const selected = isSelected(activeField, value);
+                      return (
+                        <Box
+                          key={value}
+                          role="option"
+                          aria-selected={selected}
+                          tabIndex={0}
+                          onClick={() => toggleFilter(activeField, value)}
+                          onKeyDown={(event) => {
+                            if (event.key !== "Enter" && event.key !== " ") {
+                              return;
+                            }
+                            event.preventDefault();
+                            toggleFilter(activeField, value);
+                          }}
+                          sx={(theme) => ({
+                            minWidth: 0,
+                            width: "100%",
+                            borderRadius: 0.75,
+                            px: 1.25,
+                            py: 0.5,
+                            cursor: "pointer",
+                            boxSizing: "border-box",
+                            bgcolor: selected
+                              ? theme.palette.primary.main
+                              : theme.palette.background.paper,
+                            color: selected
+                              ? theme.palette.primary.contrastText
+                              : theme.palette.text.primary,
+                            "&:hover, &:focus-visible": {
+                              outline: "none",
+                              bgcolor: selected
+                                ? theme.palette.primary.dark
+                                : theme.palette.action.hover,
+                            },
+                          })}>
+                          <Typography
+                            component="span"
+                            variant="caption"
+                            title={value}
+                            sx={{
+                              display: "block",
+                              minWidth: 0,
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                              whiteSpace: "nowrap",
+                            }}>
+                            {value}
+                          </Typography>
+                        </Box>
+                      );
+                    })
+                  ) : (
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ px: 0.5, py: 0.75 }}>
+                      {t("pages.connections.filters.noOptions")}
+                    </Typography>
+                  )}
+                </Box>
+              </Box>
+            </Box>
+          </Paper>
+        </Popper>
+      </Box>
+    </ClickAwayListener>
+  );
+};

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -221,6 +221,16 @@
         "rule": "Rule",
         "dragToReorder": "Drag to reorder columns",
         "startAt": "Start at {{time}}"
+      },
+      "filters": {
+        "placeholder": "Filter by connection fields",
+        "noOptions": "No filter values",
+        "destinationIP": "Destination IP",
+        "destinationPort": "Destination Port",
+        "sourceIP": "Source IP",
+        "sourcePort": "Source Port",
+        "network": "Network",
+        "inbound": "Inbound"
       }
     },
     "rules": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -224,6 +224,7 @@
       },
       "filters": {
         "placeholder": "Filter by connection fields",
+        "hostPlaceholder": "Search host",
         "noOptions": "No filter values",
         "destinationIP": "Destination IP",
         "destinationPort": "Destination Port",

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -224,6 +224,7 @@
       },
       "filters": {
         "placeholder": "فیلتر بر اساس فیلدهای اتصال",
+        "hostPlaceholder": "جستجوی میزبان",
         "noOptions": "مقداری برای فیلتر نیست",
         "destinationIP": "IP مقصد",
         "destinationPort": "پورت مقصد",

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -221,6 +221,16 @@
         "rule": "قانون",
         "dragToReorder": "برای تغییر ترتیب ستون‌ها بکشید",
         "startAt": "شروع در {{time}}"
+      },
+      "filters": {
+        "placeholder": "فیلتر بر اساس فیلدهای اتصال",
+        "noOptions": "مقداری برای فیلتر نیست",
+        "destinationIP": "IP مقصد",
+        "destinationPort": "پورت مقصد",
+        "sourceIP": "IP مبدا",
+        "sourcePort": "پورت مبدا",
+        "network": "شبکه",
+        "inbound": "ورودی"
       }
     },
     "rules": {

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -224,6 +224,7 @@
       },
       "filters": {
         "placeholder": "Фильтр по полям соединения",
+        "hostPlaceholder": "Поиск хоста",
         "noOptions": "Нет значений фильтра",
         "destinationIP": "IP назначения",
         "destinationPort": "Порт назначения",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -221,6 +221,16 @@
         "rule": "Правило",
         "dragToReorder": "Перетаскивайте для изменения порядка столбцов",
         "startAt": "Начато в {{time}}"
+      },
+      "filters": {
+        "placeholder": "Фильтр по полям соединения",
+        "noOptions": "Нет значений фильтра",
+        "destinationIP": "IP назначения",
+        "destinationPort": "Порт назначения",
+        "sourceIP": "IP источника",
+        "sourcePort": "Порт источника",
+        "network": "Сеть",
+        "inbound": "Входящее"
       }
     },
     "rules": {

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -224,6 +224,7 @@
       },
       "filters": {
         "placeholder": "按连接字段过滤",
+        "hostPlaceholder": "搜索主机",
         "noOptions": "暂无可过滤值",
         "destinationIP": "目标 IP",
         "destinationPort": "目标端口",

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -221,6 +221,16 @@
         "rule": "规则",
         "dragToReorder": "拖动以调整列顺序",
         "startAt": "开始于{{time}}"
+      },
+      "filters": {
+        "placeholder": "按连接字段过滤",
+        "noOptions": "暂无可过滤值",
+        "destinationIP": "目标 IP",
+        "destinationPort": "目标端口",
+        "sourceIP": "源 IP",
+        "sourcePort": "源端口",
+        "network": "网络",
+        "inbound": "入站"
       }
     },
     "rules": {

--- a/src/pages/connections.tsx
+++ b/src/pages/connections.tsx
@@ -47,6 +47,29 @@ const SCROLL_TOP_VISIBLE_THRESHOLD = 240;
 const getScrollerTop = (scroller: HTMLElement | Window) =>
   "scrollY" in scroller ? scroller.scrollY : scroller.scrollTop;
 
+const orderOpts: Record<
+  ConnectionsOrderType,
+  { labelKey: string; sort: OrderFunc }
+> = {
+  Default: {
+    labelKey: "common.status.default",
+    sort: (list) =>
+      list.sort(
+        (a, b) =>
+          new Date(b.start || "0").getTime()! -
+          new Date(a.start || "0").getTime()!,
+      ),
+  },
+  "Upload Speed": {
+    labelKey: "pages.connections.columns.uploadSpeed",
+    sort: (list) => list.sort((a, b) => b.curUpload! - a.curUpload!),
+  },
+  "Download Speed": {
+    labelKey: "pages.connections.columns.downloadSpeed",
+    sort: (list) => list.sort((a, b) => b.curDownload! - a.curDownload!),
+  },
+};
+
 const ConnectionsPage = () => {
   const { t } = useTranslation();
   const [filters, setFilters] = useState<ConnectionFilter[]>([]);
@@ -65,29 +88,6 @@ const ConnectionsPage = () => {
 
   const isTableLayout = connLayout === "table";
   const isActiveTab = tabName === "active";
-
-  const orderOpts: Record<
-    ConnectionsOrderType,
-    { labelKey: string; sort: OrderFunc }
-  > = {
-    Default: {
-      labelKey: "common.status.default",
-      sort: (list) =>
-        list.sort(
-          (a, b) =>
-            new Date(b.start || "0").getTime()! -
-            new Date(a.start || "0").getTime()!,
-        ),
-    },
-    "Upload Speed": {
-      labelKey: "pages.connections.columns.uploadSpeed",
-      sort: (list) => list.sort((a, b) => b.curUpload! - a.curUpload!),
-    },
-    "Download Speed": {
-      labelKey: "pages.connections.columns.downloadSpeed",
-      sort: (list) => list.sort((a, b) => b.curDownload! - a.curDownload!),
-    },
-  };
 
   const {
     response: { data: connData = initConnData },
@@ -138,7 +138,6 @@ const ConnectionsPage = () => {
     matchesConnectionFilters,
     matchesHostSearch,
     normalizedHostSearch,
-    orderFunc,
   ]);
 
   const onCloseAll = useLockFn(async () => {

--- a/src/pages/connections.tsx
+++ b/src/pages/connections.tsx
@@ -15,21 +15,21 @@ import {
   Zoom,
 } from "@mui/material";
 import { useLockFn } from "ahooks";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { closeAllConnections, closeConnection } from "tauri-plugin-mihomo-api";
 
-import {
-  BaseEmpty,
-  BasePage,
-  BaseSearchBox,
-  BaseStyledSelect,
-} from "@/components/base";
+import { BaseEmpty, BasePage, BaseStyledSelect } from "@/components/base";
 import {
   ConnectionDetail,
   ConnectionDetailRef,
 } from "@/components/connection/connection-detail";
+import {
+  ConnectionFilter,
+  ConnectionFilterBox,
+  createConnectionFilterMatcher,
+} from "@/components/connection/connection-filter-box";
 import { ConnectionItem } from "@/components/connection/connection-item";
 import { ConnectionTable } from "@/components/connection/connection-table";
 import {
@@ -49,7 +49,7 @@ const getScrollerTop = (scroller: HTMLElement | Window) =>
 
 const ConnectionsPage = () => {
   const { t } = useTranslation();
-  const [match, setMatch] = useState(() => (_: string) => true);
+  const [filters, setFilters] = useState<ConnectionFilter[]>([]);
   const connLayout = useConnectionsStore((s) => s.layout);
   const setConnectionsLayout = useConnectionsStore(
     (s) => s.setConnectionsLayout,
@@ -102,12 +102,21 @@ const ConnectionsPage = () => {
   // filter connections
   const orderFunc = orderOpts[curOrderOpt]?.sort;
   const conns = isActiveTab ? activeConns : closedConns;
-  let filterConn = conns.filter((conn) =>
-    match(conn.metadata.host || conn.metadata.destinationIP || ""),
+  const matchesConnectionFilters = useMemo(
+    () => createConnectionFilterMatcher(filters),
+    [filters],
   );
-  if (orderFunc) filterConn = orderFunc(filterConn);
-  if (!isActiveTab)
-    filterConn = filterConn.sort((a, b) => b.closedTime - a.closedTime);
+  const filterConn = useMemo(() => {
+    let filteredConnections = conns.filter(matchesConnectionFilters);
+    if (orderFunc) filteredConnections = orderFunc(filteredConnections);
+    if (!isActiveTab) {
+      filteredConnections = filteredConnections.sort(
+        (a, b) => b.closedTime - a.closedTime,
+      );
+    }
+
+    return filteredConnections;
+  }, [conns, isActiveTab, matchesConnectionFilters, orderFunc]);
 
   const onCloseAll = useLockFn(async () => {
     if (
@@ -266,7 +275,11 @@ const ConnectionsPage = () => {
               ))}
             </BaseStyledSelect>
           )}
-          <BaseSearchBox onSearch={(match) => setMatch(() => match)} />
+          <ConnectionFilterBox
+            connections={conns}
+            filters={filters}
+            onChange={setFilters}
+          />
         </Box>
 
         <Box

--- a/src/pages/connections.tsx
+++ b/src/pages/connections.tsx
@@ -107,7 +107,7 @@ const ConnectionsPage = () => {
     [filters],
   );
   const filterConn = useMemo(() => {
-    let filteredConnections = conns.filter(matchesConnectionFilters);
+    let filteredConnections = filters.length > 0 ? conns.filter(matchesConnectionFilters) : [...conns];
     if (orderFunc) filteredConnections = orderFunc(filteredConnections);
     if (!isActiveTab) {
       filteredConnections = filteredConnections.sort(

--- a/src/pages/connections.tsx
+++ b/src/pages/connections.tsx
@@ -50,6 +50,7 @@ const getScrollerTop = (scroller: HTMLElement | Window) =>
 const ConnectionsPage = () => {
   const { t } = useTranslation();
   const [filters, setFilters] = useState<ConnectionFilter[]>([]);
+  const [hostSearch, setHostSearch] = useState("");
   const connLayout = useConnectionsStore((s) => s.layout);
   const setConnectionsLayout = useConnectionsStore(
     (s) => s.setConnectionsLayout,
@@ -106,8 +107,22 @@ const ConnectionsPage = () => {
     () => createConnectionFilterMatcher(filters),
     [filters],
   );
+  const normalizedHostSearch = hostSearch.trim().toLowerCase();
+  const matchesHostSearch = useMemo(() => {
+    if (!normalizedHostSearch) return () => true;
+
+    return (conn: IClosedConnectionItem) => {
+      const host = conn.metadata.host || conn.metadata.destinationIP || "";
+      return host.toLowerCase().includes(normalizedHostSearch);
+    };
+  }, [normalizedHostSearch]);
   const filterConn = useMemo(() => {
-    let filteredConnections = filters.length > 0 ? conns.filter(matchesConnectionFilters) : [...conns];
+    let filteredConnections =
+      filters.length > 0 || normalizedHostSearch
+        ? conns.filter(
+            (conn) => matchesConnectionFilters(conn) && matchesHostSearch(conn),
+          )
+        : [...conns];
     if (orderFunc) filteredConnections = orderFunc(filteredConnections);
     if (!isActiveTab) {
       filteredConnections = filteredConnections.sort(
@@ -116,7 +131,15 @@ const ConnectionsPage = () => {
     }
 
     return filteredConnections;
-  }, [conns, isActiveTab, matchesConnectionFilters, orderFunc]);
+  }, [
+    conns,
+    filters.length,
+    isActiveTab,
+    matchesConnectionFilters,
+    matchesHostSearch,
+    normalizedHostSearch,
+    orderFunc,
+  ]);
 
   const onCloseAll = useLockFn(async () => {
     if (
@@ -278,7 +301,9 @@ const ConnectionsPage = () => {
           <ConnectionFilterBox
             connections={conns}
             filters={filters}
+            hostSearch={hostSearch}
             onChange={setFilters}
+            onHostSearchChange={setHostSearch}
           />
         </Box>
 


### PR DESCRIPTION
## 变更概述
- 将连接页原有的简单文本搜索替换为连接搜索过滤框
- 拆分 host 模糊搜索与属性字段过滤两个入口，避免输入搜索和字段过滤交互混在一起
- 支持按 host / destinationIP 模糊搜索，并支持按多个连接属性字段叠加过滤
- 字段过滤候选项会基于当前 host 搜索结果和其他已选字段动态联动
- 优化字段候选值计算，减少 WebSocket 高频刷新时的重复遍历和重复 `getValues` 调用
- 优化已选过滤标签布局，避免标签过多撑高或拉宽工具栏
- 补充中英俄波斯语连接过滤相关文案

## 主要改动
- 新增 `src/components/connection/connection-filter-box.tsx`
  - 独立过滤按钮打开属性字段过滤面板
  - 搜索框使用 host / destinationIP 模糊匹配
  - 已选字段过滤以紧凑标签展示，支持单项删除和统一清空
  - 属性面板左侧显示字段列表和候选数量，右侧显示当前字段值列表，并支持值列表内搜索
  - 按连接预计算 host 匹配结果和各字段 values，再生成所有字段候选项，避免按字段重复扫描连接数据
  - 候选值未变化时复用数组引用，减少右侧列表重渲染并保留滚动位置
- 更新 `src/pages/connections.tsx`
  - 移除 `BaseSearchBox`
  - 新增 `filters` 与 `hostSearch` 状态
  - 使用 `createConnectionFilterMatcher` 与 host 搜索共同过滤 active / closed 连接
- 更新 `src/locales/en.json`、`src/locales/zh_CN.json`、`src/locales/ru.json`、`src/locales/fa.json`
  - 新增连接过滤占位符、空状态和字段名翻译

## 影响范围
- 连接页 active / closed 列表过滤逻辑
- 连接页列表布局和表格布局下的过滤结果
- 连接页过滤相关多语言显示

## 验证情况
- `pnpm exec prettier --write src/components/connection/connection-filter-box.tsx`
- `pnpm exec eslint src/components/connection/connection-filter-box.tsx --max-warnings=0`
- `pnpm exec eslint src/pages/connections.tsx src/components/connection/connection-filter-box.tsx --max-warnings=0`
- `pnpm exec tsc --noEmit`
- `git diff --check`
- `git diff --check origin/dev...HEAD`
- `npx gitnexus detect-changes --scope unstaged`

## 差异统计
- `src/components/connection/connection-filter-box.tsx` 新增连接过滤组件，并包含候选值计算性能优化
- `src/pages/connections.tsx` 接入新搜索过滤逻辑
- 4 个 locale 文件新增连接过滤文案
- 相对 `origin/dev...HEAD`：6 files changed, 824 insertions(+), 14 deletions(-)
