### PR TITLE
perf(connections): simplify connection view rendering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **clash-verge-self** (5039 symbols, 9562 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **clash-verge-self** (5267 symbols, 9861 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **clash-verge-self** (5039 symbols, 9562 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **clash-verge-self** (5267 symbols, 9861 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/src/components/connection/connection-filter-box.tsx
+++ b/src/components/connection/connection-filter-box.tsx
@@ -54,11 +54,6 @@ type ConnectionFilterFieldConfig = {
   getValues: (connection: IClosedConnectionItem) => string[];
 };
 
-type CachedConnectionFilterValues = {
-  hostMatched: boolean;
-  valuesMap: Map<ConnectionFilterField, string[]>;
-};
-
 const compactValues = (values: Array<string | number | null | undefined>) => {
   const result: string[] = [];
   for (const value of values) {
@@ -212,15 +207,6 @@ export const ConnectionFilterBox = ({
   const [valueSearch, setValueSearch] = useState("");
   const filterButtonRef = useRef<HTMLButtonElement | null>(null);
   const valueListRef = useRef<HTMLDivElement | null>(null);
-  const fieldValuesCacheRef = useRef(
-    new Map<
-      ConnectionFilterField,
-      {
-        signature: string;
-        values: string[];
-      }
-    >(),
-  );
   const fieldLabelMap = useMemo(() => {
     return new Map(
       CONNECTION_FILTER_FIELDS.map(({ field, labelKey }) => [
@@ -233,82 +219,30 @@ export const ConnectionFilterBox = ({
   const fieldValuesMap = useMemo(() => {
     if (!open) return new Map<ConnectionFilterField, string[]>();
     const normalizedHostSearch = hostSearch.trim().toLowerCase();
-    // 先按字段聚合已选过滤值，避免为每个候选字段重复构建匹配器。
-    const filtersByField = new Map<ConnectionFilterField, Set<string>>();
-    filters.forEach(({ field, value }) => {
-      const values = filtersByField.get(field) ?? new Set<string>();
-      values.add(value.toLowerCase());
-      filtersByField.set(field, values);
-    });
-
-    // 连接数据会随 WebSocket 高频刷新。这里按连接预计算所有字段值，
-    // 后续生成各字段候选列表时直接复用。
-    const cachedConnections = connections.map<CachedConnectionFilterValues>(
-      (connection) => {
-        const host =
-          connection.metadata.host || connection.metadata.destinationIP || "";
-        const valuesMap = new Map<ConnectionFilterField, string[]>();
-
-        CONNECTION_FILTER_FIELDS.forEach(({ field, getValues }) => {
-          valuesMap.set(field, getValues(connection));
-        });
-
-        return {
-          hostMatched:
-            !normalizedHostSearch ||
-            host.toLowerCase().includes(normalizedHostSearch),
-          valuesMap,
-        };
-      },
-    );
-
-    const uniqueValuesByField = new Map<ConnectionFilterField, Set<string>>();
-    CONNECTION_FILTER_FIELDS.forEach(({ field }) => {
-      uniqueValuesByField.set(field, new Set<string>());
-    });
-
-    cachedConnections.forEach(({ hostMatched, valuesMap }) => {
-      if (!hostMatched) return;
-
-      // 某个字段的候选值应受其他已选字段限制，但不受自身限制。
-      // 记录当前连接未命中的字段，用于判断它还能贡献给哪些字段候选项。
-      const unmatchedFilterFields = new Set<ConnectionFilterField>();
-      for (const [filterField, expectedValues] of filtersByField) {
-        const values = valuesMap.get(filterField) ?? EMPTY_VALUES;
-        const matched = values.some((value) =>
-          expectedValues.has(value.toLowerCase()),
-        );
-        if (!matched) unmatchedFilterFields.add(filterField);
-      }
-
-      CONNECTION_FILTER_FIELDS.forEach(({ field }) => {
-        const canUseConnection =
-          unmatchedFilterFields.size === 0 ||
-          (unmatchedFilterFields.size === 1 &&
-            unmatchedFilterFields.has(field));
-
-        if (!canUseConnection) return;
-        const uniqueValues = uniqueValuesByField.get(field);
-        valuesMap.get(field)?.forEach((value) => uniqueValues?.add(value));
-      });
-    });
 
     const nextMap = new Map<ConnectionFilterField, string[]>();
-    CONNECTION_FILTER_FIELDS.forEach(({ field }) => {
-      const uniqueValues = uniqueValuesByField.get(field) ?? new Set<string>();
-      const values = Array.from(uniqueValues).sort((left, right) =>
-        left.localeCompare(right),
-      );
-      const signature = values.join("\u0000");
-      const cached = fieldValuesCacheRef.current.get(field);
-      // 候选值未变化时复用数组引用，减少右侧列表重渲染并保留滚动位置。
-      if (cached?.signature === signature) {
-        nextMap.set(field, cached.values);
-        return;
-      }
+    CONNECTION_FILTER_FIELDS.forEach(({ field, getValues }) => {
+      const matchesOtherFields = createConnectionFilterMatcher(filters, field);
+      const values = new Set<string>();
 
-      fieldValuesCacheRef.current.set(field, { signature, values });
-      nextMap.set(field, values);
+      connections.forEach((connection) => {
+        const host =
+          connection.metadata.host || connection.metadata.destinationIP || "";
+        if (
+          normalizedHostSearch &&
+          !host.toLowerCase().includes(normalizedHostSearch)
+        ) {
+          return;
+        }
+        if (!matchesOtherFields(connection)) return;
+
+        getValues(connection).forEach((value) => values.add(value));
+      });
+
+      nextMap.set(
+        field,
+        Array.from(values).sort((left, right) => left.localeCompare(right)),
+      );
     });
 
     return nextMap;

--- a/src/components/connection/connection-item.tsx
+++ b/src/components/connection/connection-item.tsx
@@ -39,7 +39,15 @@ export const ConnectionItem = (props: Props) => {
   const { id, metadata, chains, start, curUpload, curDownload } = value;
 
   const onDelete = useLockFn(async () => closeConnection(id));
-  const showTraffic = curUpload! >= 100 || curDownload! >= 100;
+  const uploadSpeed = curUpload ?? 0;
+  const downloadSpeed = curDownload ?? 0;
+  const chainText = chains?.length ? [...chains].reverse().join(" / ") : "";
+  const showTraffic = uploadSpeed >= 100 || downloadSpeed >= 100;
+  const trafficText = showTraffic
+    ? `${parseTraffic(uploadSpeed).join(" ")} / ${parseTraffic(
+        downloadSpeed,
+      ).join(" ")}`
+    : "";
 
   return (
     <ListItem
@@ -70,9 +78,7 @@ export const ConnectionItem = (props: Props) => {
 
             {!!metadata.process && <Tag>{metadata.process}</Tag>}
 
-            {chains?.length > 0 && (
-              <Tag>{[...chains].reverse().join(" / ")}</Tag>
-            )}
+            {!!chainText && <Tag>{chainText}</Tag>}
 
             <Tag>
               {t("pages.connections.columns.startAt", {
@@ -80,11 +86,7 @@ export const ConnectionItem = (props: Props) => {
               })}
             </Tag>
 
-            {showTraffic && (
-              <Tag>
-                {parseTraffic(curUpload!)} / {parseTraffic(curDownload!)}
-              </Tag>
-            )}
+            {!!trafficText && <Tag>{trafficText}</Tag>}
           </span>
         }
       />

--- a/src/components/connection/connection-table-column-selector.tsx
+++ b/src/components/connection/connection-table-column-selector.tsx
@@ -1,12 +1,10 @@
 import { isSortable } from "@dnd-kit/dom/sortable";
 import { DragDropProvider } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
-import CancelIcon from "@mui/icons-material/Close";
+import CloseRounded from "@mui/icons-material/CloseRounded";
 import DragIndicatorRounded from "@mui/icons-material/DragIndicatorRounded";
 import { Backdrop, Box, Checkbox, IconButton } from "@mui/material";
 import { useRef, useState } from "react";
-
-import { cn } from "@/utils";
 
 import { ColumnOption } from "./connection-table.types";
 
@@ -28,17 +26,27 @@ const SortableColumnOption = ({
     handle: handleRef,
   });
   return (
-    <div
-      className={cn("bg-white", {
-        "shadow-[0_0_10px_5px_rgba(0,0,0,0.2)]": isDragging,
-      })}
+    <Box
       ref={setElement}
-      data-show={isDragging || undefined}>
-      <div className="flex items-center gap-2 rounded-md px-3 py-2 hover:bg-[rgba(0,0,0,0.04)]">
+      data-show={isDragging || undefined}
+      sx={(theme) => ({
+        bgcolor: "background.paper",
+        ...(isDragging && {
+          boxShadow: theme.shadows[8],
+        }),
+      })}>
+      <Box
+        className="flex items-center gap-2 px-3 py-2"
+        sx={{
+          borderRadius: 1,
+          "&:hover": {
+            bgcolor: "action.hover",
+          },
+        }}>
         <button
           ref={handleRef}
           type="button"
-          className="cursor-grab text-[rgba(0,0,0,0.48)] active:cursor-grabbing"
+          className="cursor-grab active:cursor-grabbing"
           aria-label={`Drag ${option.label}`}>
           <DragIndicatorRounded fontSize="small" />
         </button>
@@ -49,8 +57,8 @@ const SortableColumnOption = ({
           <Checkbox checked={option.visible} size="small" tabIndex={-1} />
           <span className="truncate">{option.label}</span>
         </button>
-      </div>
-    </div>
+      </Box>
+    </Box>
   );
 };
 
@@ -86,7 +94,7 @@ export const ConnectionTableColumnSelector = ({
           maxHeight: "min(560px, calc(100vh - 32px))",
           overflow: "hidden",
           border: `1px solid ${theme.palette.divider}`,
-          borderRadius: "14px",
+          borderRadius: 1,
           bgcolor: theme.palette.background.paper,
           boxShadow: theme.shadows[16],
         })}>
@@ -100,22 +108,24 @@ export const ConnectionTableColumnSelector = ({
             <div className="text-xs opacity-60">{description}</div>
           </div>
           <IconButton size="small" onClick={onClose}>
-            <CancelIcon fontSize="small" />
+            <CloseRounded fontSize="small" />
           </IconButton>
         </Box>
 
-        <div className="max-h-105 overflow-y-auto px-2 py-2">
+        <Box
+          sx={{
+            maxHeight: "calc(min(560px, calc(100vh - 32px)) - 65px)",
+            overflowY: "auto",
+            px: 1,
+            py: 1,
+          }}>
           <DragDropProvider
             onDragEnd={(event) => {
               const { operation, canceled } = event;
               const { source, target } = operation;
-              if (canceled) return;
+              if (canceled || !target || !isSortable(source)) return;
 
-              if (target && isSortable(source)) {
-                const newIndex = source.sortable.index;
-                const oldIndex = source.sortable.initialIndex;
-                onDragEnd(oldIndex, newIndex);
-              }
+              onDragEnd(source.sortable.initialIndex, source.sortable.index);
             }}>
             <div className="space-y-1">
               {columns.map((column, index) => (
@@ -128,7 +138,7 @@ export const ConnectionTableColumnSelector = ({
               ))}
             </div>
           </DragDropProvider>
-        </div>
+        </Box>
       </Box>
     </Backdrop>
   );

--- a/src/components/connection/connection-table.tsx
+++ b/src/components/connection/connection-table.tsx
@@ -106,7 +106,6 @@ const ConnectionTableBodyRow = memo(
             cell.column.columnDef.cell,
             cell.getContext(),
           );
-          const tooltipText = getCellTooltipText(cell);
 
           return (
             <td
@@ -122,9 +121,17 @@ const ConnectionTableBodyRow = memo(
                 justifyContent,
               }}>
               <span
-                title={tooltipText || undefined}
                 className="flex h-full w-full items-center overflow-hidden text-sm text-ellipsis whitespace-nowrap"
-                style={{ justifyContent }}>
+                style={{ justifyContent }}
+                onPointerEnter={(event) => {
+                  const tooltipText = getCellTooltipText(cell);
+                  if (tooltipText) {
+                    event.currentTarget.title = tooltipText;
+                    return;
+                  }
+
+                  event.currentTarget.removeAttribute("title");
+                }}>
                 <span
                   className="min-w-0 overflow-hidden leading-tight text-ellipsis whitespace-nowrap"
                   data-column-content="true">

--- a/src/components/connection/connection-table.tsx
+++ b/src/components/connection/connection-table.tsx
@@ -91,11 +91,13 @@ const ConnectionTableBodyRow = memo(
         data-body-row="true"
         onClick={() => onShowDetail(row.original.connectionData)}
         style={{
+          contain: "layout style paint",
           display: "flex",
           position: "absolute",
-          transform: `translateY(${virtualRow.start}px)`,
+          transform: `translate3d(0, ${virtualRow.start}px, 0)`,
           width: "100%",
           height: `${virtualRow.size}px`,
+          willChange: "transform",
         }}>
         {row.getVisibleCells().map((cell) => {
           const meta = cell.column.columnDef.meta as ColumnMeta | undefined;
@@ -119,23 +121,15 @@ const ConnectionTableBodyRow = memo(
                 position: "relative",
                 justifyContent,
               }}>
-              <Tooltip
-                followCursor
-                title={tooltipText}
-                disableHoverListener={!tooltipText}>
-                <span
-                  className="flex h-full w-full items-center overflow-hidden text-sm text-ellipsis whitespace-nowrap"
-                  style={{ justifyContent }}
-                  data-column-content="true">
-                  <span className="min-w-0 overflow-hidden leading-tight text-ellipsis whitespace-nowrap">
-                    {renderedCell}
-                  </span>
-                </span>
-              </Tooltip>
               <span
-                className="pointer-events-none invisible absolute px-3 whitespace-nowrap"
-                data-column-measure="true">
-                {renderedCell}
+                title={tooltipText || undefined}
+                className="flex h-full w-full items-center overflow-hidden text-sm text-ellipsis whitespace-nowrap"
+                style={{ justifyContent }}>
+                <span
+                  className="min-w-0 overflow-hidden leading-tight text-ellipsis whitespace-nowrap"
+                  data-column-content="true">
+                  {renderedCell}
+                </span>
               </span>
             </td>
           );
@@ -166,18 +160,20 @@ const ConnectionTableBody = memo(
       estimateSize: () => ROW_HEIGHT,
       getScrollElement: () => tableContainerElement,
       getItemKey: (index) => rows[index]?.id ?? index,
-      overscan: 5,
+      overscan: 3,
     });
 
     return (
       <tbody
         style={{
+          contain: "layout style paint",
           display: "grid",
           height: `${rowVirtualizer.getTotalSize()}px`,
           position: "relative",
         }}>
         {rowVirtualizer.getVirtualItems().map((virtualRow) => {
           const row = rows[virtualRow.index];
+          if (!row) return null;
 
           return (
             <ConnectionTableBodyRow
@@ -367,7 +363,7 @@ export const ConnectionTable = (props: Props) => {
           ? CSS.escape(columnId)
           : columnId;
       const contents = container.querySelectorAll<HTMLElement>(
-        `[data-column-id="${selectorColumnId}"] [data-column-measure="true"]`,
+        `[data-column-id="${selectorColumnId}"] [data-column-content="true"]`,
       );
       if (contents.length === 0) return;
 
@@ -503,10 +499,10 @@ export const ConnectionTable = (props: Props) => {
                         : "100%",
                     }}
                     onClick={header.column.getToggleSortingHandler()}>
-                    <span className="truncate" data-column-content="true">
+                    <span className="truncate">
                       <span
                         className="inline-block max-w-none"
-                        data-column-measure="true">
+                        data-column-content="true">
                         {header.isPlaceholder
                           ? null
                           : flexRender(
@@ -587,7 +583,7 @@ export const ConnectionTable = (props: Props) => {
 
   return (
     <Box className="flex h-full min-h-0 flex-col">
-      <Box className="flex items-center px-1 py-1">
+      <Box className="flex shrink-0 items-center justify-end px-1 py-1">
         <Tooltip title={t("pages.connections.columns.actions")}>
           <IconButton
             size="small"

--- a/src/components/connection/connection-table.tsx
+++ b/src/components/connection/connection-table.tsx
@@ -167,7 +167,7 @@ const ConnectionTableBody = memo(
       estimateSize: () => ROW_HEIGHT,
       getScrollElement: () => tableContainerElement,
       getItemKey: (index) => rows[index]?.id ?? index,
-      overscan: 3,
+      overscan: 5,
     });
 
     return (

--- a/src/pages/connections.tsx
+++ b/src/pages/connections.tsx
@@ -37,10 +37,17 @@ import {
   initConnData,
   useConnectionData,
 } from "@/hooks/use-connection-data";
-import { type ConnectionsOrderType, useConnectionsStore } from "@/stores";
+import {
+  type ConnectionsOrderType,
+  type ConnectionsTabName,
+  useConnectionsStore,
+} from "@/stores";
 import parseTraffic from "@/utils/parse-traffic";
 
-type OrderFunc = (list: IClosedConnectionItem[]) => IClosedConnectionItem[];
+type OrderCompare = (
+  a: IClosedConnectionItem,
+  b: IClosedConnectionItem,
+) => number;
 
 const SCROLL_TOP_VISIBLE_THRESHOLD = 240;
 
@@ -49,26 +56,25 @@ const getScrollerTop = (scroller: HTMLElement | Window) =>
 
 const orderOpts: Record<
   ConnectionsOrderType,
-  { labelKey: string; sort: OrderFunc }
+  { labelKey: string; compare: OrderCompare }
 > = {
   Default: {
     labelKey: "common.status.default",
-    sort: (list) =>
-      list.sort(
-        (a, b) =>
-          new Date(b.start || "0").getTime()! -
-          new Date(a.start || "0").getTime()!,
-      ),
+    compare: (a, b) =>
+      new Date(b.start || "0").getTime() - new Date(a.start || "0").getTime(),
   },
   "Upload Speed": {
     labelKey: "pages.connections.columns.uploadSpeed",
-    sort: (list) => list.sort((a, b) => b.curUpload! - a.curUpload!),
+    compare: (a, b) => (b.curUpload ?? 0) - (a.curUpload ?? 0),
   },
   "Download Speed": {
     labelKey: "pages.connections.columns.downloadSpeed",
-    sort: (list) => list.sort((a, b) => b.curDownload! - a.curDownload!),
+    compare: (a, b) => (b.curDownload ?? 0) - (a.curDownload ?? 0),
   },
 };
+
+const compareClosedConnections: OrderCompare = (a, b) =>
+  b.closedTime - a.closedTime;
 
 const ConnectionsPage = () => {
   const { t } = useTranslation();
@@ -80,7 +86,7 @@ const ConnectionsPage = () => {
   );
   const curOrderOpt = useConnectionsStore((s) => s.curOrderOpt);
   const setOrderType = useConnectionsStore((s) => s.setOrderType);
-  const [tabName, setTabName] = useState("active");
+  const [tabName, setTabName] = useState<ConnectionsTabName>("active");
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<VirtuosoHandle>(null);
   const listScrollerRef = useRef<HTMLElement | Window | null>(null);
@@ -100,54 +106,36 @@ const ConnectionsPage = () => {
   const activeConns = connData.activeConnections;
   const closedConns = connData.closedConnections;
 
-  // filter connections
-  const orderFunc = orderOpts[curOrderOpt]?.sort;
-  const conns = isActiveTab ? activeConns : closedConns;
-  const matchesConnectionFilters = useMemo(
-    () => createConnectionFilterMatcher(filters),
-    [filters],
-  );
-  const normalizedHostSearch = hostSearch.trim().toLowerCase();
-  const matchesHostSearch = useMemo(() => {
-    if (!normalizedHostSearch) return () => true;
+  const currentConnections = isActiveTab ? activeConns : closedConns;
+  const filteredConnections = useMemo(() => {
+    const normalizedHostSearch = hostSearch.trim().toLowerCase();
+    const matchesFilters = createConnectionFilterMatcher(filters);
+    const compareConnections = isActiveTab
+      ? (orderOpts[curOrderOpt] ?? orderOpts.Default).compare
+      : compareClosedConnections;
 
-    return (conn: IClosedConnectionItem) => {
-      const host = conn.metadata.host || conn.metadata.destinationIP || "";
-      return host.toLowerCase().includes(normalizedHostSearch);
-    };
-  }, [normalizedHostSearch]);
-  const filterConn = useMemo(() => {
-    let filteredConnections =
-      filters.length > 0 || normalizedHostSearch
-        ? conns.filter(
-            (conn) => matchesConnectionFilters(conn) && matchesHostSearch(conn),
-          )
-        : [...conns];
-    if (orderFunc) filteredConnections = orderFunc(filteredConnections);
-    if (!isActiveTab) {
-      filteredConnections = filteredConnections.sort(
-        (a, b) => b.closedTime - a.closedTime,
-      );
-    }
+    return currentConnections
+      .filter((conn) => {
+        const host = conn.metadata.host || conn.metadata.destinationIP || "";
+        const matchesHost =
+          !normalizedHostSearch ||
+          host.toLowerCase().includes(normalizedHostSearch);
 
-    return filteredConnections;
-  }, [
-    conns,
-    filters.length,
-    isActiveTab,
-    matchesConnectionFilters,
-    matchesHostSearch,
-    normalizedHostSearch,
-  ]);
+        return matchesHost && matchesFilters(conn);
+      })
+      .sort(compareConnections);
+  }, [currentConnections, curOrderOpt, filters, hostSearch, isActiveTab]);
 
   const onCloseAll = useLockFn(async () => {
     if (
       !isActiveTab ||
-      filterConn.length === connData.activeConnections.length
+      filteredConnections.length === connData.activeConnections.length
     ) {
       await closeAllConnections();
     } else {
-      await Promise.all(filterConn.map((conn) => closeConnection(conn.id)));
+      await Promise.all(
+        filteredConnections.map((conn) => closeConnection(conn.id)),
+      );
     }
   });
 
@@ -163,6 +151,15 @@ const ConnectionsPage = () => {
     }
   }, [isTableLayout]);
 
+  const handleTabChange = useCallback(
+    (nextTab: ConnectionsTabName) => {
+      setTabName(nextTab);
+      setShowScrollTop(false);
+      requestAnimationFrame(scrollToTop);
+    },
+    [scrollToTop],
+  );
+
   const handleListScrollerRef = useCallback(
     (ref: HTMLElement | Window | null) => {
       listScrollerRef.current = ref;
@@ -175,7 +172,7 @@ const ConnectionsPage = () => {
       ? tableContainerRef.current
       : listScrollerRef.current;
 
-    if (!scroller || filterConn.length === 0) {
+    if (!scroller || filteredConnections.length === 0) {
       setShowScrollTop(false);
       return;
     }
@@ -192,7 +189,7 @@ const ConnectionsPage = () => {
     return () => {
       scroller.removeEventListener("scroll", updateScrollTopVisible);
     };
-  }, [filterConn.length > 0, isTableLayout, tabName]);
+  }, [filteredConnections.length, isTableLayout, tabName]);
 
   return (
     <BasePage
@@ -204,17 +201,17 @@ const ConnectionsPage = () => {
       }
       contentStyle={{ height: "100%" }}
       header={
-        <div className="mx-2 flex items-center overflow-hidden">
-          <div className="flex w-full items-center space-x-2 p-2">
-            <div className="flex w-fit items-center space-x-4">
-              <div className="flex w-full items-center space-x-1">
+        <div className="mx-2 flex min-w-0 items-center gap-2 overflow-hidden p-2">
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            <div className="flex w-fit shrink-0 items-center gap-4">
+              <div className="flex items-center gap-1">
                 <Tooltip title={t("pages.connections.columns.totalUploaded")}>
                   <Upload fontSize="small" />
                 </Tooltip>
                 <span className="text-sm">{totalUpload[0]}</span>
                 <span className="text-sm">{totalUpload[1]}</span>
               </div>
-              <div className="flex w-full items-center space-x-1">
+              <div className="flex items-center gap-1">
                 <Tooltip title={t("pages.connections.columns.totalDownloaded")}>
                   <Download fontSize="small" />
                 </Tooltip>
@@ -222,65 +219,55 @@ const ConnectionsPage = () => {
                 <span className="text-sm">{totalDownload[1]}</span>
               </div>
             </div>
-            <IconButton
-              color="inherit"
-              size="small"
+            <Tooltip
               title={
                 isTableLayout
                   ? t("pages.connections.view.list")
                   : t("pages.connections.view.table")
-              }
-              onClick={() =>
-                setConnectionsLayout(isTableLayout ? "list" : "table")
               }>
-              {isTableLayout ? (
-                <TableRowsRounded fontSize="inherit" />
-              ) : (
-                <TableChartRounded fontSize="inherit" />
-              )}
-            </IconButton>
+              <IconButton
+                color="inherit"
+                size="small"
+                onClick={() =>
+                  setConnectionsLayout(isTableLayout ? "list" : "table")
+                }>
+                {isTableLayout ? (
+                  <TableRowsRounded fontSize="inherit" />
+                ) : (
+                  <TableChartRounded fontSize="inherit" />
+                )}
+              </IconButton>
+            </Tooltip>
           </div>
-          <div>
-            <Button size="small" variant="contained" onClick={onCloseAll}>
-              <span style={{ whiteSpace: "nowrap" }}>
-                {t("pages.connections.actions.closeAll")}{" "}
-                {isActiveTab ? filterConn.length : activeConns.length}
-              </span>
-            </Button>
-          </div>
+          <Button size="small" variant="contained" onClick={onCloseAll}>
+            <span className="whitespace-nowrap">
+              {t("pages.connections.actions.closeAll")}{" "}
+              {isActiveTab ? filteredConnections.length : activeConns.length}
+            </span>
+          </Button>
         </div>
       }>
-      <div className="relative h-full w-full overflow-hidden">
+      <div className="relative flex h-full w-full flex-col overflow-hidden">
         <Box
           sx={{
-            mb: "10px",
-            pt: "10px",
             mx: "10px",
-            height: "36px",
+            py: "10px",
             display: "flex",
             alignItems: "center",
+            gap: 1,
+            flexShrink: 0,
             userSelect: "text",
             boxSizing: "border-box",
           }}>
-          <ButtonGroup size="small" className="mr-2 w-fit shrink-0 grow-0">
+          <ButtonGroup size="small" className="w-fit shrink-0 grow-0">
             <Button
               variant={isActiveTab ? "contained" : "outlined"}
-              onClick={() => {
-                setTabName("active");
-                if (isTableLayout && tableContainerRef.current) {
-                  tableContainerRef.current.scrollTo({ top: 0 });
-                }
-              }}>
+              onClick={() => handleTabChange("active")}>
               {t("common.status.active")} {activeConns.length}
             </Button>
             <Button
               variant={!isActiveTab ? "contained" : "outlined"}
-              onClick={() => {
-                setTabName("closed");
-                if (isTableLayout && tableContainerRef.current) {
-                  tableContainerRef.current.scrollTo({ top: 0 });
-                }
-              }}>
+              onClick={() => handleTabChange("closed")}>
               {t("common.status.closed")} {closedConns.length}
             </Button>
           </ButtonGroup>
@@ -298,7 +285,7 @@ const ConnectionsPage = () => {
             </BaseStyledSelect>
           )}
           <ConnectionFilterBox
-            connections={conns}
+            connections={currentConnections}
             filters={filters}
             hostSearch={hostSearch}
             onChange={setFilters}
@@ -309,7 +296,8 @@ const ConnectionsPage = () => {
         <Box
           sx={[
             {
-              height: "calc(100% - 50px)",
+              flex: 1,
+              minHeight: 0,
             },
             (theme) => ({
               userSelect: "text",
@@ -323,12 +311,12 @@ const ConnectionsPage = () => {
               boxSizing: "border-box",
             }),
           ]}>
-          {filterConn.length === 0 ? (
+          {filteredConnections.length === 0 ? (
             <BaseEmpty text={t("common.empty.noConnections")} />
           ) : isTableLayout ? (
             <ConnectionTable
               tableContainerRef={tableContainerRef}
-              connections={filterConn}
+              connections={filteredConnections}
               isActive={isActiveTab}
               onShowDetail={(detail) =>
                 detailRef.current?.open(detail, isActiveTab)
@@ -338,7 +326,7 @@ const ConnectionsPage = () => {
             <Virtuoso
               ref={listRef}
               scrollerRef={handleListScrollerRef}
-              data={filterConn}
+              data={filteredConnections}
               itemContent={(_, item) => (
                 <ConnectionItem
                   key={item.id}
@@ -368,7 +356,7 @@ const ConnectionsPage = () => {
             </Fab>
           </Tooltip>
         </Zoom>
-        <Zoom in={!isActiveTab && filterConn.length > 0} unmountOnExit>
+        <Zoom in={!isActiveTab && filteredConnections.length > 0} unmountOnExit>
           <Fab
             size="medium"
             variant="extended"


### PR DESCRIPTION
## 变更概述
- 优化连接页布局，减少硬编码高度和重复分支逻辑
- 简化连接筛选候选值生成，降低组件内部复杂度
- 优化连接表格滚动渲染，减少 cell 级 Tooltip 和额外测量 DOM 带来的滚动开销

## 主要改动
- 重整 `src/pages/connections.tsx` 的过滤、排序、tab 切换和滚动到顶部逻辑
- 简化 `connection-filter-box.tsx` 的候选项计算，移除额外缓存层
- 优化 `connection-table.tsx` 的虚拟行渲染路径，降低滚动卡顿
- 调整连接列表项和列选择器的局部实现与样式一致性

## 验证情况
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint src/pages/connections.tsx src/components/connection/connection-filter-box.tsx src/components/connection/connection-item.tsx src/components/connection/connection-table-column-selector.tsx src/components/connection/connection-table.tsx --max-warnings=0`
- `git diff --cached --check`
- `gitnexus_detect_changes(scope: staged)`：MEDIUM，仅命中 `ConnectionsPage → getScrollerTop` 流程

## 备注
- 基于 `origin/dev` 比较差异：5 个连接相关文件，166 insertions / 236 deletions
- 工作区仍有未提交的 GitNexus 文档/技能文件改动，本 PR 未纳入这些文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **性能优化**
  * 改进了连接表虚拟化渲染与浏览器合成策略，提升大列表滚动与绘制性能

* **用户界面改进**
  * 优化了连接过滤框的候选值生成与交互体验
  * 改进了列选择器的拖拽样式与弹窗布局
  * 优化了连接项的网速与链路信息显示
  * 将单元格提示切换为原生 title 行为以减轻渲染开销

* **行为改进**
  * 调整了连接列表的排序、过滤及“全部关闭/仅可见关闭”逻辑

* **文档**
  * 更新了项目索引统计元数据 (两处文件)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oomeow/clash-verge-self/pull/2022)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->