### PR TITLE
refactor(VergerLog): improve log file cleanup process

### DIFF
--- a/src-tauri/src/config/verge.rs
+++ b/src-tauri/src/config/verge.rs
@@ -155,7 +155,7 @@ pub struct IVerge {
     /// 测试网站列表
     pub test_list: Option<Vec<IVergeTestItem>>,
 
-    /// 日志清理
+    /// 日志清理, 默认 7 天
     /// 0: 不清理; 1: 7天; 2: 30天; 3: 90天
     pub auto_log_clean: Option<i32>,
 
@@ -331,7 +331,7 @@ impl IVerge {
             proxy_guard_duration: Some(30),
             auto_close_connection: Some(true),
             auto_check_update: Some(true),
-            auto_log_clean: Some(3),
+            auto_log_clean: Some(1),
             enable_tray: Some(true),
             keep_in_dock: Some(true),
             enable_external_controller: Some(false),

--- a/src-tauri/src/core/verge_log.rs
+++ b/src-tauri/src/core/verge_log.rs
@@ -20,6 +20,7 @@ use tracing_subscriber::{
 
 use crate::{
     config::Config,
+    log_err,
     utils::dirs::{self},
 };
 
@@ -132,10 +133,9 @@ impl VergeLog {
             _ => return Ok(()),
         };
 
-        tracing::debug!("try to delete log files, day: {retention_days}");
-
+        tracing::debug!("try to delete log files, retention_days: {retention_days}");
         for file in fs::read_dir(&log_dir)?.flatten() {
-            delete_old_logs(file, retention_days)?;
+            log_err!(delete_old_logs(file, retention_days))
         }
 
         Ok(())
@@ -161,9 +161,11 @@ fn parse_time_str(s: &str) -> Result<NaiveDateTime> {
 
 fn delete_old_logs(file: DirEntry, retention_days: i64) -> Result<()> {
     if file.file_type()?.is_dir() {
-        tracing::trace!("delete log process dir: {}", file.path().display());
-        for file in fs::read_dir(file.path())?.flatten() {
-            delete_old_logs(file, retention_days)?;
+        if let Ok(files) = fs::read_dir(file.path()) {
+            tracing::trace!("delete log process dir: {}", file.path().display());
+            for file in files.flatten() {
+                log_err!(delete_old_logs(file, retention_days))
+            }
         }
     } else {
         let file_name = file.file_name();
@@ -179,8 +181,10 @@ fn delete_old_logs(file: DirEntry, retention_days: i64) -> Result<()> {
 
                 if now.signed_duration_since(file_time).num_days() > retention_days {
                     let file_path = file.path();
-                    fs::remove_file(file_path).with_context(|| format!("delete file failed: {}", file_name))?;
-                    tracing::info!("delete log file: {file_name}");
+                    match fs::remove_file(&file_path) {
+                        Ok(_) => tracing::info!("delete log file: {file_name}"),
+                        Err(e) => tracing::warn!("Failed to delete log file {}: {}", file_path.display(), e),
+                    }
                 }
             } else {
                 tracing::warn!("parse time failed, skip delete log file [{file_name}]");

--- a/src-tauri/src/core/verge_log.rs
+++ b/src-tauri/src/core/verge_log.rs
@@ -134,8 +134,9 @@ impl VergeLog {
         };
 
         tracing::debug!("try to delete log files, retention_days: {retention_days}");
+        let now = Local::now();
         for file in fs::read_dir(&log_dir)?.flatten() {
-            log_err!(delete_old_logs(file, retention_days))
+            log_err!(delete_old_logs(file, now, retention_days))
         }
 
         Ok(())
@@ -159,18 +160,17 @@ fn parse_time_str(s: &str) -> Result<NaiveDateTime> {
     Ok(time)
 }
 
-fn delete_old_logs(file: DirEntry, retention_days: i64) -> Result<()> {
+fn delete_old_logs(file: DirEntry, now: chrono::DateTime<Local>, retention_days: i64) -> Result<()> {
     if file.file_type()?.is_dir() {
         if let Ok(files) = fs::read_dir(file.path()) {
             tracing::trace!("delete log process dir: {}", file.path().display());
             for file in files.flatten() {
-                log_err!(delete_old_logs(file, retention_days))
+                log_err!(delete_old_logs(file, now, retention_days))
             }
         }
     } else {
         let file_name = file.file_name();
         let file_name = file_name.to_str().unwrap_or_default();
-        let now = Local::now();
 
         if file_name.ends_with(".log") {
             if let Ok(created_time) = parse_time_str(file_name.trim_end_matches(".log")) {

--- a/src-tauri/src/core/verge_log.rs
+++ b/src-tauri/src/core/verge_log.rs
@@ -136,13 +136,13 @@ impl VergeLog {
         tracing::debug!("try to delete log files, day: {day}");
 
         for file in fs::read_dir(&log_dir)?.flatten() {
-            log_err!(process_file(file, day));
+            log_err!(delete_log_file(file, day));
         }
 
         let service_log_dir = log_dir.join("service");
         if service_log_dir.exists() {
             for file in fs::read_dir(service_log_dir)?.flatten() {
-                log_err!(process_file(file, day));
+                log_err!(delete_log_file(file, day));
             }
         }
 
@@ -150,7 +150,7 @@ impl VergeLog {
     }
 }
 
-// Parse log filename format %Y-%m-%d-%H%M to NaiveDateTime, but only use the date part
+/// parse log filename format %Y-%m-%d-%H%M to NaiveDateTime, but only use the date part
 fn parse_time_str(s: &str) -> Result<NaiveDateTime> {
     let sa = s.split('-').collect::<Vec<&str>>();
     if sa.len() != 4 {
@@ -167,11 +167,11 @@ fn parse_time_str(s: &str) -> Result<NaiveDateTime> {
     Ok(time)
 }
 
-fn process_file(file: DirEntry, day: i64) -> Result<()> {
+fn delete_log_file(file: DirEntry, day: i64) -> Result<()> {
     if file.file_type()?.is_dir() {
         tracing::trace!("delete log process dir: {}", file.path().display());
         for file in fs::read_dir(file.path())?.flatten() {
-            process_file(file, day)?;
+            delete_log_file(file, day)?;
         }
     } else {
         let file_name = file.file_name();

--- a/src-tauri/src/core/verge_log.rs
+++ b/src-tauri/src/core/verge_log.rs
@@ -150,8 +150,7 @@ impl VergeLog {
     }
 }
 
-// Parse log filename format %Y-%m-%d-%H%M to NaiveDateTime
-fn parse_time_str(s: &str) -> Result<NaiveDateTime> {
+// Parse log filename format %Y-%m-%d-%H%M to NaiveDateTime, but only use the date part
 fn parse_time_str(s: &str) -> Result<NaiveDateTime> {
     let sa = s.split('-').collect::<Vec<&str>>();
     if sa.len() != 4 {

--- a/src-tauri/src/core/verge_log.rs
+++ b/src-tauri/src/core/verge_log.rs
@@ -168,9 +168,9 @@ fn delete_old_logs(file: DirEntry, retention_days: i64) -> Result<()> {
     } else {
         let file_name = file.file_name();
         let file_name = file_name.to_str().unwrap_or_default();
+        let now = Local::now();
 
         if file_name.ends_with(".log") {
-            let now = Local::now();
             if let Ok(created_time) = parse_time_str(file_name.trim_end_matches(".log")) {
                 let file_time = Local
                     .from_local_datetime(&created_time)

--- a/src-tauri/src/core/verge_log.rs
+++ b/src-tauri/src/core/verge_log.rs
@@ -20,7 +20,6 @@ use tracing_subscriber::{
 
 use crate::{
     config::Config,
-    log_err,
     utils::dirs::{self},
 };
 
@@ -114,7 +113,7 @@ impl VergeLog {
         Ok(())
     }
 
-    pub fn delete_log() -> Result<()> {
+    pub fn delete_logs() -> Result<()> {
         let log_dir = dirs::app_logs_dir()?;
         if !log_dir.exists() {
             return Ok(());
@@ -126,24 +125,17 @@ impl VergeLog {
             verge.auto_log_clean.unwrap_or(1)
         };
 
-        let day = match auto_log_clean {
+        let retention_days = match auto_log_clean {
             1 => 7,
             2 => 30,
             3 => 90,
             _ => return Ok(()),
         };
 
-        tracing::debug!("try to delete log files, day: {day}");
+        tracing::debug!("try to delete log files, day: {retention_days}");
 
         for file in fs::read_dir(&log_dir)?.flatten() {
-            log_err!(delete_log_file(file, day));
-        }
-
-        let service_log_dir = log_dir.join("service");
-        if service_log_dir.exists() {
-            for file in fs::read_dir(service_log_dir)?.flatten() {
-                log_err!(delete_log_file(file, day));
-            }
+            delete_old_logs(file, retention_days)?;
         }
 
         Ok(())
@@ -167,11 +159,11 @@ fn parse_time_str(s: &str) -> Result<NaiveDateTime> {
     Ok(time)
 }
 
-fn delete_log_file(file: DirEntry, day: i64) -> Result<()> {
+fn delete_old_logs(file: DirEntry, retention_days: i64) -> Result<()> {
     if file.file_type()?.is_dir() {
         tracing::trace!("delete log process dir: {}", file.path().display());
         for file in fs::read_dir(file.path())?.flatten() {
-            delete_log_file(file, day)?;
+            delete_old_logs(file, retention_days)?;
         }
     } else {
         let file_name = file.file_name();
@@ -179,23 +171,19 @@ fn delete_log_file(file: DirEntry, day: i64) -> Result<()> {
 
         if file_name.ends_with(".log") {
             let now = Local::now();
-            match parse_time_str(&file_name[0..file_name.len() - 4]) {
-                Ok(created_time) => {
-                    let file_time = Local
-                        .from_local_datetime(&created_time)
-                        .earliest()
-                        .context("invalid local datetime")?;
+            if let Ok(created_time) = parse_time_str(file_name.trim_end_matches(".log")) {
+                let file_time = Local
+                    .from_local_datetime(&created_time)
+                    .earliest()
+                    .context("invalid local datetime")?;
 
-                    let duration = now.signed_duration_since(file_time);
-                    if duration.num_days() > day {
-                        let file_path = file.path();
-                        log_err!(fs::remove_file(file_path), "delete file failed");
-                        tracing::info!("delete log file: {file_name}");
-                    }
+                if now.signed_duration_since(file_time).num_days() > retention_days {
+                    let file_path = file.path();
+                    fs::remove_file(file_path).with_context(|| format!("delete file failed: {}", file_name))?;
+                    tracing::info!("delete log file: {file_name}");
                 }
-                Err(e) => {
-                    tracing::warn!("ignore log file [{file_name}], {e}");
-                }
+            } else {
+                tracing::warn!("parse time failed, skip delete log file [{file_name}]");
             }
         }
     }

--- a/src-tauri/src/core/verge_log.rs
+++ b/src-tauri/src/core/verge_log.rs
@@ -159,22 +159,25 @@ fn parse_time_str(s: &str) -> Result<NaiveDateTime> {
 }
 
 fn delete_old_logs(file: DirEntry, now: chrono::DateTime<Local>, retention_days: i64) {
+    let Ok(file_type) = file.file_type() else {
+        return;
+    };
     let file_path = file.path();
     let file_name = file.file_name();
     let file_name = file_name.to_str().unwrap_or_default();
-    if !file_name.ends_with(".log") {
-        tracing::debug!("skip non-log file: {}", file_name);
-        return;
-    }
 
-    if file.file_type().is_ok_and(|f| f.is_dir()) {
+    if file_type.is_dir() {
         if let Ok(files) = fs::read_dir(&file_path) {
             tracing::debug!("process dir: {}", file_name);
             files
                 .flatten()
                 .for_each(|file| delete_old_logs(file, now, retention_days));
         }
-    } else if file.file_type().is_ok_and(|f| f.is_file()) {
+    } else if file_type.is_file() {
+        if !file_name.ends_with(".log") {
+            tracing::debug!("skip non-log file: {}", file_name);
+            return;
+        }
         if let Ok(created_time) = parse_time_str(file_name.trim_end_matches(".log")) {
             if let Some(file_time) = Local.from_local_datetime(&created_time).earliest() {
                 if now.signed_duration_since(file_time).num_days() > retention_days {

--- a/src-tauri/src/core/verge_log.rs
+++ b/src-tauri/src/core/verge_log.rs
@@ -150,7 +150,8 @@ impl VergeLog {
     }
 }
 
-// %Y-%m-%d to NaiveDateTime
+// Parse log filename format %Y-%m-%d-%H%M to NaiveDateTime
+fn parse_time_str(s: &str) -> Result<NaiveDateTime> {
 fn parse_time_str(s: &str) -> Result<NaiveDateTime> {
     let sa = s.split('-').collect::<Vec<&str>>();
     if sa.len() != 4 {

--- a/src-tauri/src/core/verge_log.rs
+++ b/src-tauri/src/core/verge_log.rs
@@ -20,7 +20,6 @@ use tracing_subscriber::{
 
 use crate::{
     config::Config,
-    log_err,
     utils::dirs::{self},
 };
 
@@ -135,10 +134,9 @@ impl VergeLog {
 
         tracing::debug!("try to delete log files, retention_days: {retention_days}");
         let now = Local::now();
-        for file in fs::read_dir(&log_dir)?.flatten() {
-            log_err!(delete_old_logs(file, now, retention_days))
-        }
-
+        fs::read_dir(&log_dir)?
+            .flatten()
+            .for_each(|file| delete_old_logs(file, now, retention_days));
         Ok(())
     }
 }
@@ -160,36 +158,36 @@ fn parse_time_str(s: &str) -> Result<NaiveDateTime> {
     Ok(time)
 }
 
-fn delete_old_logs(file: DirEntry, now: chrono::DateTime<Local>, retention_days: i64) -> Result<()> {
-    if file.file_type()?.is_dir() {
-        if let Ok(files) = fs::read_dir(file.path()) {
-            tracing::trace!("delete log process dir: {}", file.path().display());
-            for file in files.flatten() {
-                log_err!(delete_old_logs(file, now, retention_days))
-            }
+fn delete_old_logs(file: DirEntry, now: chrono::DateTime<Local>, retention_days: i64) {
+    let file_path = file.path();
+    let file_name = file.file_name();
+    let file_name = file_name.to_str().unwrap_or_default();
+    if !file_name.ends_with(".log") {
+        tracing::debug!("skip non-log file: {}", file_name);
+        return;
+    }
+
+    if file.file_type().is_ok_and(|f| f.is_dir()) {
+        if let Ok(files) = fs::read_dir(&file_path) {
+            tracing::debug!("process dir: {}", file_name);
+            files
+                .flatten()
+                .for_each(|file| delete_old_logs(file, now, retention_days));
         }
-    } else {
-        let file_name = file.file_name();
-        let file_name = file_name.to_str().unwrap_or_default();
-
-        if file_name.ends_with(".log") {
-            if let Ok(created_time) = parse_time_str(file_name.trim_end_matches(".log")) {
-                let file_time = Local
-                    .from_local_datetime(&created_time)
-                    .earliest()
-                    .context("invalid local datetime")?;
-
+    } else if file.file_type().is_ok_and(|f| f.is_file()) {
+        if let Ok(created_time) = parse_time_str(file_name.trim_end_matches(".log")) {
+            if let Some(file_time) = Local.from_local_datetime(&created_time).earliest() {
                 if now.signed_duration_since(file_time).num_days() > retention_days {
-                    let file_path = file.path();
                     match fs::remove_file(&file_path) {
                         Ok(_) => tracing::info!("delete log file: {file_name}"),
                         Err(e) => tracing::warn!("Failed to delete log file {}: {}", file_path.display(), e),
                     }
                 }
             } else {
-                tracing::warn!("parse time failed, skip delete log file [{file_name}]");
+                tracing::warn!("get local datetime failed, skip delete log file [{file_name}]");
             }
+        } else {
+            tracing::warn!("parse log file time failed, skip delete log file [{file_name}]");
         }
     }
-    Ok(())
 }

--- a/src-tauri/src/core/verge_log.rs
+++ b/src-tauri/src/core/verge_log.rs
@@ -184,7 +184,7 @@ fn process_file(file: DirEntry, day: i64) -> Result<()> {
                 Ok(created_time) => {
                     let file_time = Local
                         .from_local_datetime(&created_time)
-                        .single()
+                        .earliest()
                         .context("invalid local datetime")?;
 
                     let duration = now.signed_duration_since(file_time);

--- a/src-tauri/src/core/verge_log.rs
+++ b/src-tauri/src/core/verge_log.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-use chrono::{Local, TimeZone};
+use chrono::{Local, NaiveDateTime, TimeZone};
 use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
 use time::macros::format_description;
@@ -123,74 +123,81 @@ impl VergeLog {
         let auto_log_clean = {
             let verge = Config::verge();
             let verge = verge.data();
-            verge.auto_log_clean.unwrap_or(0)
+            verge.auto_log_clean.unwrap_or(1)
         };
 
         let day = match auto_log_clean {
             1 => 7,
             2 => 30,
             3 => 90,
-            _ => return Ok(()),
+            _ => 7, // default to 7 days
         };
 
         tracing::debug!("try to delete log files, day: {day}");
 
-        // %Y-%m-%d to NaiveDateTime
-        let parse_time_str = |s: &str| {
-            let sa = s.split('-').collect::<Vec<&str>>();
-            if sa.len() != 4 {
-                anyhow::bail!("invalid time str: {s}.log");
-            }
-
-            let year = i32::from_str(sa[0])?;
-            let month = u32::from_str(sa[1])?;
-            let day = u32::from_str(sa[2])?;
-            let time = chrono::NaiveDate::from_ymd_opt(year, month, day)
-                .context("invalid time str")?
-                .and_hms_opt(0, 0, 0)
-                .context("invalid time str")?;
-            Ok(time)
-        };
-
-        let process_file = |file: DirEntry| -> Result<()> {
-            let file_name = file.file_name();
-            let file_name = file_name.to_str().unwrap_or_default();
-
-            if file_name.ends_with(".log") {
-                let now = Local::now();
-                match parse_time_str(&file_name[0..file_name.len() - 4]) {
-                    Ok(created_time) => {
-                        let file_time = Local
-                            .from_local_datetime(&created_time)
-                            .single()
-                            .context("invalid local datetime")?;
-
-                        let duration = now.signed_duration_since(file_time);
-                        if duration.num_days() > day {
-                            let file_path = file.path();
-                            log_err!(fs::remove_file(file_path), "delete file failed");
-                            tracing::info!("delete log file: {file_name}");
-                        }
-                    }
-                    Err(e) => {
-                        tracing::warn!("ignore log file [{file_name}], {e}");
-                    }
-                }
-            }
-            Ok(())
-        };
-
         for file in fs::read_dir(&log_dir)?.flatten() {
-            log_err!(process_file(file));
+            log_err!(process_file(file, day));
         }
 
         let service_log_dir = log_dir.join("service");
         if service_log_dir.exists() {
             for file in fs::read_dir(service_log_dir)?.flatten() {
-                log_err!(process_file(file));
+                log_err!(process_file(file, day));
             }
         }
 
         Ok(())
     }
+}
+
+// %Y-%m-%d to NaiveDateTime
+fn parse_time_str(s: &str) -> Result<NaiveDateTime> {
+    let sa = s.split('-').collect::<Vec<&str>>();
+    if sa.len() != 4 {
+        anyhow::bail!("invalid time str: {s}.log");
+    }
+
+    let year = i32::from_str(sa[0])?;
+    let month = u32::from_str(sa[1])?;
+    let day = u32::from_str(sa[2])?;
+    let time = chrono::NaiveDate::from_ymd_opt(year, month, day)
+        .context("invalid time str")?
+        .and_hms_opt(0, 0, 0)
+        .context("invalid time str")?;
+    Ok(time)
+}
+
+fn process_file(file: DirEntry, day: i64) -> Result<()> {
+    if file.file_type()?.is_dir() {
+        tracing::trace!("delete log process dir: {}", file.path().display());
+        for file in fs::read_dir(file.path())?.flatten() {
+            process_file(file, day)?;
+        }
+    } else {
+        let file_name = file.file_name();
+        let file_name = file_name.to_str().unwrap_or_default();
+
+        if file_name.ends_with(".log") {
+            let now = Local::now();
+            match parse_time_str(&file_name[0..file_name.len() - 4]) {
+                Ok(created_time) => {
+                    let file_time = Local
+                        .from_local_datetime(&created_time)
+                        .single()
+                        .context("invalid local datetime")?;
+
+                    let duration = now.signed_duration_since(file_time);
+                    if duration.num_days() > day {
+                        let file_path = file.path();
+                        log_err!(fs::remove_file(file_path), "delete file failed");
+                        tracing::info!("delete log file: {file_name}");
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!("ignore log file [{file_name}], {e}");
+                }
+            }
+        }
+    }
+    Ok(())
 }

--- a/src-tauri/src/core/verge_log.rs
+++ b/src-tauri/src/core/verge_log.rs
@@ -130,7 +130,7 @@ impl VergeLog {
             1 => 7,
             2 => 30,
             3 => 90,
-            _ => 7, // default to 7 days
+            _ => return Ok(()),
         };
 
         tracing::debug!("try to delete log files, day: {day}");

--- a/src-tauri/src/utils/resolve.rs
+++ b/src-tauri/src/utils/resolve.rs
@@ -47,7 +47,7 @@ pub fn async_initialization() {
         tracing::trace!("init startup script");
         log_err!(init::startup_script().await);
         tracing::trace!("delete old log files");
-        log_err!(VergeLog::delete_log());
+        log_err!(VergeLog::delete_logs());
         tracing::trace!("launch embed server");
         server::embed_server().await;
         tracing::trace!("init autolaunch");


### PR DESCRIPTION
recursive logs file deletion, e.g. cleanup clash dir's log files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 日志默认清理保留期改为 7 天，避免旧日志长期累积。
  * 改进过期日志识别与删除的可靠性，修正本地时区计算的边缘情况，减少磁盘占用。

* **Refactor**
  * 日志清理内部实现重构为更模块化、可维护的流程，优化目录遍历与过期文件处理。

* **行为变更**
  * 启动时将执行日志清理以应用保留策略。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oomeow/clash-verge-self/pull/2033)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->