### PR TITLE
feat(mihomo-rule-parser): add export functionality for rule parser

### DIFF
--- a/crates/mihomo-rule-parser/src/classical.rs
+++ b/crates/mihomo-rule-parser/src/classical.rs
@@ -24,6 +24,8 @@ impl Codec for ClassicalCodecStrategy {
     }
 }
 
+// ------------------------------ Test ------------------------------------
+
 #[cfg(test)]
 #[allow(deprecated)]
 mod tests {

--- a/crates/mihomo-rule-parser/src/classical.rs
+++ b/crates/mihomo-rule-parser/src/classical.rs
@@ -1,13 +1,13 @@
 use crate::{
-    Parser, RuleBehavior, RuleFormat,
+    Codec, RuleBehavior, RuleFormat,
     error::{Result, RuleParseError},
     utils,
 };
 
 /// classical parse strategy
-pub(crate) struct ClassicalParseStrategy;
+pub(crate) struct ClassicalCodecStrategy;
 
-impl Parser for ClassicalParseStrategy {
+impl Codec for ClassicalCodecStrategy {
     fn parse(buf: &[u8], format: crate::RuleFormat) -> Result<crate::RulePayload> {
         match format {
             RuleFormat::Mrs => Err(RuleParseError::UnsupportedFormat(
@@ -17,6 +17,10 @@ impl Parser for ClassicalParseStrategy {
             RuleFormat::Yaml => utils::parse_from_yaml(buf),
             RuleFormat::Text => utils::parse_from_text(buf),
         }
+    }
+
+    fn export<P: AsRef<std::path::Path>>(_rules: &[String], _file_path: P, format: RuleFormat) -> Result<()> {
+        Err(RuleParseError::UnsupportedExportFormat(RuleBehavior::Classical, format))
     }
 }
 
@@ -61,7 +65,7 @@ mod tests {
         let mut file = std::fs::File::open(rules_dir.join("geo/geoip/ad.mrs"))?;
         let mut buf = Vec::new();
         file.read_to_end(&mut buf)?;
-        let payload = ClassicalParseStrategy::parse(&buf, RuleFormat::Mrs);
+        let payload = ClassicalCodecStrategy::parse(&buf, RuleFormat::Mrs);
         assert!(matches!(
             payload,
             Err(RuleParseError::UnsupportedFormat(
@@ -78,7 +82,7 @@ mod tests {
         let mut file = std::fs::File::open(rules_dir.join("geo/geoip/classical/ad.yaml"))?;
         let mut buf = Vec::new();
         file.read_to_end(&mut buf)?;
-        let payload = ClassicalParseStrategy::parse(&buf, RuleFormat::Yaml)?;
+        let payload = ClassicalCodecStrategy::parse(&buf, RuleFormat::Yaml)?;
         println!("payload: {:?}", payload);
         Ok(())
     }
@@ -89,7 +93,7 @@ mod tests {
         let mut file = std::fs::File::open(rules_dir.join("geo/geoip/classical/ad.list"))?;
         let mut buf = Vec::new();
         file.read_to_end(&mut buf)?;
-        let payload = ClassicalParseStrategy::parse(&buf, RuleFormat::Text)?;
+        let payload = ClassicalCodecStrategy::parse(&buf, RuleFormat::Text)?;
         println!("payload: {:?}", payload);
         Ok(())
     }

--- a/crates/mihomo-rule-parser/src/domain.rs
+++ b/crates/mihomo-rule-parser/src/domain.rs
@@ -141,13 +141,13 @@ fn parse_from_mrs(buf: &[u8]) -> Result<RulePayload> {
     let mut version = [0u8; 1];
     reader.read_exact(&mut version)?;
     if version[0] != MRS_VERSION {
-        return Err(RuleParseError::InvalidVersion);
+        return Err(RuleParseError::InvalidMRSVersion);
     }
 
     // leaves
     let length = reader.read_i64::<BigEndian>()?;
     if length < 0 {
-        return Err(RuleParseError::InvalidLength(length));
+        return Err(RuleParseError::InvalidMRSLength(length));
     }
     let mut leaves = vec![0u64; length as usize];
     for i in 0..length {
@@ -158,7 +158,7 @@ fn parse_from_mrs(buf: &[u8]) -> Result<RulePayload> {
     // label bitmap
     let length = reader.read_i64::<BigEndian>()?;
     if length < 0 {
-        return Err(RuleParseError::InvalidLength(length));
+        return Err(RuleParseError::InvalidMRSLength(length));
     }
     let mut label_bit_map = vec![0u64; length as usize];
     for i in 0..length {
@@ -169,7 +169,7 @@ fn parse_from_mrs(buf: &[u8]) -> Result<RulePayload> {
     // labels
     let length = reader.read_i64::<BigEndian>()?;
     if length < 0 {
-        return Err(RuleParseError::InvalidLength(length));
+        return Err(RuleParseError::InvalidMRSLength(length));
     }
     let mut labels = vec![0u8; length as usize];
     reader.read_exact(&mut labels)?;

--- a/crates/mihomo-rule-parser/src/domain.rs
+++ b/crates/mihomo-rule-parser/src/domain.rs
@@ -224,12 +224,10 @@ fn export_as_mrs<P: AsRef<Path>>(rules: &[String], file_path: P) -> Result<()> {
 }
 
 fn export_mrs_body<W: Write>(rules: &[String], writer: &mut W) -> Result<i64> {
-    // let mut count = 0i64;
     let mut keys = Vec::new();
 
     for rule in rules {
         let expanded = expand_rule(rule)?;
-        // count += 1;
         keys.extend(expanded.into_iter().map(|domain| reverse_string(&domain)));
     }
 

--- a/crates/mihomo-rule-parser/src/domain.rs
+++ b/crates/mihomo-rule-parser/src/domain.rs
@@ -112,6 +112,94 @@ fn select_ith_one(bm: &[u64], ranks: &[i32], selects: &[i32], i: isize) -> isize
     a as isize
 }
 
+fn set_bit_u(bitmap: &mut Vec<u64>, index: usize, value: u64) {
+    while (index >> 6) >= bitmap.len() {
+        bitmap.push(0);
+    }
+
+    bitmap[index >> 6] |= value << (index & 63);
+}
+
+// ------------------------------ Parse ------------------------------------
+
+fn parse_from_mrs(buf: &[u8]) -> Result<RulePayload> {
+    // create ZSTD decoder
+    let mut reader = zstd::Decoder::new(Cursor::new(buf))?;
+
+    // validate mrs file
+    let (actual_behavior, count) = utils::read_mrs_header(&mut reader)?;
+    if actual_behavior != RuleBehavior::Domain {
+        return Err(RuleParseError::BehaviorMismatch {
+            expected: RuleBehavior::Domain,
+            actual: actual_behavior,
+        });
+    }
+
+    let mut domain_set = DomainSet::new();
+
+    // version
+    let mut version = [0u8; 1];
+    reader.read_exact(&mut version)?;
+    if version[0] != 1 {
+        return Err(RuleParseError::InvalidVersion);
+    }
+
+    // leaves
+    let length = reader.read_i64::<BigEndian>()?;
+    if length < 0 {
+        return Err(RuleParseError::InvalidLength(length));
+    }
+    let mut leaves = vec![0u64; length as usize];
+    for i in 0..length {
+        leaves[i as usize] = reader.read_u64::<BigEndian>()?;
+    }
+    domain_set.leaves = leaves;
+
+    // label bitmap
+    let length = reader.read_i64::<BigEndian>()?;
+    if length < 0 {
+        return Err(RuleParseError::InvalidLength(length));
+    }
+    let mut label_bit_map = vec![0u64; length as usize];
+    for i in 0..length {
+        label_bit_map[i as usize] = reader.read_u64::<BigEndian>()?;
+    }
+    domain_set.label_bit_map = label_bit_map;
+
+    // labels
+    let length = reader.read_i64::<BigEndian>()?;
+    if length < 0 {
+        return Err(RuleParseError::InvalidLength(length));
+    }
+    let mut labels = vec![0u8; length as usize];
+    reader.read_exact(&mut labels)?;
+    drop(reader);
+
+    domain_set.labels = labels;
+    domain_set.init();
+
+    // get rules
+    let mut rules: Vec<String> = vec![];
+    let mut keys = Vec::new();
+    domain_set.foreach(|key| {
+        keys.push(key);
+        true
+    });
+    keys.sort();
+
+    for key in &keys {
+        let search_str = format!("+.{key}");
+        if keys.binary_search(&search_str).is_ok() {
+            continue;
+        }
+        rules.push(key.clone());
+    }
+
+    Ok(RulePayload { count, rules })
+}
+
+// ------------------------------ Export ------------------------------------
+
 #[derive(Clone, Copy)]
 struct QueueItem {
     start: usize,
@@ -135,7 +223,7 @@ fn export_as_mrs<P: AsRef<Path>>(rules: &[String], file_path: P) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn export_mrs_body<W: Write>(rules: &[String], writer: &mut W) -> Result<i64> {
+fn export_mrs_body<W: Write>(rules: &[String], writer: &mut W) -> Result<i64> {
     let mut count = 0i64;
     let mut keys = Vec::new();
 
@@ -229,14 +317,6 @@ fn build_domain_set(keys: &[String]) -> DomainSet {
     domain_set
 }
 
-fn set_bit_u(bitmap: &mut Vec<u64>, index: usize, value: u64) {
-    while (index >> 6) >= bitmap.len() {
-        bitmap.push(0);
-    }
-
-    bitmap[index >> 6] |= value << (index & 63);
-}
-
 fn write_domain_set<W: Write>(writer: &mut W, domain_set: &DomainSet) -> Result<()> {
     writer.write_all(&[1])?;
     writer.write_i64::<BigEndian>(domain_set.leaves.len() as i64)?;
@@ -254,75 +334,7 @@ fn write_domain_set<W: Write>(writer: &mut W, domain_set: &DomainSet) -> Result<
     Ok(())
 }
 
-fn parse_from_mrs(buf: &[u8]) -> Result<RulePayload> {
-    // create ZSTD decoder
-    let mut reader = zstd::Decoder::new(Cursor::new(buf))?;
-
-    // validate mrs file
-    let count = utils::validate_mrs(&mut reader, RuleBehavior::Domain)?;
-
-    let mut domain_set = DomainSet::new();
-
-    // version
-    let mut version = [0u8; 1];
-    reader.read_exact(&mut version)?;
-    if version[0] != 1 {
-        return Err(RuleParseError::InvalidVersion);
-    }
-
-    // leaves
-    let length = reader.read_i64::<BigEndian>()?;
-    if length < 0 {
-        return Err(RuleParseError::InvalidLength(length));
-    }
-    let mut leaves = vec![0u64; length as usize];
-    for i in 0..length {
-        leaves[i as usize] = reader.read_u64::<BigEndian>()?;
-    }
-    domain_set.leaves = leaves;
-
-    // label bitmap
-    let length = reader.read_i64::<BigEndian>()?;
-    if length < 0 {
-        return Err(RuleParseError::InvalidLength(length));
-    }
-    let mut label_bit_map = vec![0u64; length as usize];
-    for i in 0..length {
-        label_bit_map[i as usize] = reader.read_u64::<BigEndian>()?;
-    }
-    domain_set.label_bit_map = label_bit_map;
-
-    // labels
-    let length = reader.read_i64::<BigEndian>()?;
-    if length < 0 {
-        return Err(RuleParseError::InvalidLength(length));
-    }
-    let mut labels = vec![0u8; length as usize];
-    reader.read_exact(&mut labels)?;
-    drop(reader);
-
-    domain_set.labels = labels;
-    domain_set.init();
-
-    // get rules
-    let mut rules: Vec<String> = vec![];
-    let mut keys = Vec::new();
-    domain_set.foreach(|key| {
-        keys.push(key);
-        true
-    });
-    keys.sort();
-
-    for key in &keys {
-        let search_str = format!("+.{key}");
-        if keys.binary_search(&search_str).is_ok() {
-            continue;
-        }
-        rules.push(key.clone());
-    }
-
-    Ok(RulePayload { count, rules })
-}
+// ------------------------------ Test ------------------------------------
 
 #[cfg(test)]
 #[allow(deprecated)]

--- a/crates/mihomo-rule-parser/src/domain.rs
+++ b/crates/mihomo-rule-parser/src/domain.rs
@@ -1,22 +1,34 @@
-use std::io::{Cursor, Read};
+use std::{
+    collections::VecDeque,
+    io::{Cursor, Read, Write},
+    path::Path,
+};
 
-use byteorder::{BigEndian, ReadBytesExt};
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
 use crate::{
-    Parser, RuleBehavior, RuleFormat, RulePayload, bitmap,
+    Codec, RuleBehavior, RuleFormat, RulePayload, bitmap,
     error::{Result, RuleParseError},
     utils,
 };
 
 /// domain parse strategy
-pub(crate) struct DomainParseStrategy;
+pub(crate) struct DomainCodecStrategy;
 
-impl Parser for DomainParseStrategy {
+impl Codec for DomainCodecStrategy {
     fn parse(buf: &[u8], format: RuleFormat) -> Result<RulePayload> {
         match format {
             RuleFormat::Mrs => parse_from_mrs(buf),
             RuleFormat::Yaml => utils::parse_from_yaml(buf),
             RuleFormat::Text => utils::parse_from_text(buf),
+        }
+    }
+
+    fn export<P: AsRef<std::path::Path>>(rules: &[String], file_path: P, format: RuleFormat) -> Result<()> {
+        match format {
+            RuleFormat::Mrs => export_as_mrs(rules, file_path),
+            RuleFormat::Yaml => utils::export_as_yaml(rules, file_path),
+            RuleFormat::Text => utils::export_as_text(rules, file_path),
         }
     }
 }
@@ -98,6 +110,152 @@ fn count_zeros(bm: &[u64], ranks: &[i32], i: isize) -> isize {
 fn select_ith_one(bm: &[u64], ranks: &[i32], selects: &[i32], i: isize) -> isize {
     let (a, _) = bitmap::Bitmap::select_32_r64(bm, selects, ranks, i as i32);
     a as isize
+}
+
+#[derive(Clone, Copy)]
+struct QueueItem {
+    start: usize,
+    end: usize,
+    col: usize,
+}
+
+fn export_as_mrs<P: AsRef<Path>>(rules: &[String], file_path: P) -> Result<()> {
+    let mut body = Vec::new();
+    let count = export_mrs_body(rules, &mut body)?;
+
+    let mut encoded = Vec::new();
+    {
+        let mut writer = zstd::Encoder::new(&mut encoded, 0)?;
+        utils::write_mrs_header(&mut writer, RuleBehavior::Domain, count)?;
+        writer.write_all(&body)?;
+        writer.finish()?;
+    }
+
+    std::fs::write(file_path, encoded)?;
+    Ok(())
+}
+
+pub(crate) fn export_mrs_body<W: Write>(rules: &[String], writer: &mut W) -> Result<i64> {
+    let mut count = 0i64;
+    let mut keys = Vec::new();
+
+    for rule in rules {
+        let expanded = expand_rule(rule)?;
+        count += 1;
+        keys.extend(expanded.into_iter().map(|domain| reverse_string(&domain)));
+    }
+
+    keys.sort();
+    keys.dedup();
+
+    if keys.is_empty() {
+        return Err(RuleParseError::EmptyRule);
+    }
+
+    let domain_set = build_domain_set(&keys);
+    write_domain_set(writer, &domain_set)?;
+    Ok(count)
+}
+
+fn expand_rule(rule: &str) -> Result<Vec<String>> {
+    if rule.ends_with('.') || rule.trim() != rule || rule.is_empty() || rule.contains('/') {
+        return Err(RuleParseError::InvalidRule(rule.to_string()));
+    }
+
+    let normalized = rule.to_lowercase();
+    let parts: Vec<&str> = normalized.split('.').collect();
+
+    if parts.len() == 1 {
+        if parts[0].is_empty() {
+            return Err(RuleParseError::InvalidRule(rule.to_string()));
+        }
+    } else if parts.iter().skip(1).any(|part| part.is_empty()) {
+        return Err(RuleParseError::InvalidRule(rule.to_string()));
+    }
+
+    if parts[0] == "+" {
+        if parts.len() < 2 {
+            return Err(RuleParseError::InvalidRule(rule.to_string()));
+        }
+
+        let plain = parts[1..].join(".");
+        let wildcard = format!("+.{}", plain);
+        return Ok(vec![plain, wildcard]);
+    }
+
+    Ok(vec![normalized])
+}
+
+fn reverse_string(value: &str) -> String {
+    value.chars().rev().collect()
+}
+
+fn build_domain_set(keys: &[String]) -> DomainSet {
+    let mut domain_set = DomainSet::new();
+    let mut label_index = 0usize;
+    let mut queue = VecDeque::from([QueueItem {
+        start: 0,
+        end: keys.len(),
+        col: 0,
+    }]);
+    let mut node_index = 0usize;
+
+    while let Some(mut item) = queue.pop_front() {
+        if item.col == keys[item.start].len() {
+            item.start += 1;
+            set_bit_u(&mut domain_set.leaves, node_index, 1);
+        }
+
+        let mut cursor = item.start;
+        while cursor < item.end {
+            let from = cursor;
+            let label = keys[from].as_bytes()[item.col];
+            while cursor < item.end && keys[cursor].as_bytes()[item.col] == label {
+                cursor += 1;
+            }
+
+            queue.push_back(QueueItem {
+                start: from,
+                end: cursor,
+                col: item.col + 1,
+            });
+            domain_set.labels.push(label);
+            set_bit_u(&mut domain_set.label_bit_map, label_index, 0);
+            label_index += 1;
+        }
+
+        set_bit_u(&mut domain_set.label_bit_map, label_index, 1);
+        label_index += 1;
+        node_index += 1;
+    }
+
+    domain_set.init();
+    domain_set
+}
+
+fn set_bit_u(bitmap: &mut Vec<u64>, index: usize, value: u64) {
+    while (index >> 6) >= bitmap.len() {
+        bitmap.push(0);
+    }
+
+    bitmap[index >> 6] |= value << (index & 63);
+}
+
+fn write_domain_set<W: Write>(writer: &mut W, domain_set: &DomainSet) -> Result<()> {
+    writer.write_all(&[1])?;
+    writer.write_i64::<BigEndian>(domain_set.leaves.len() as i64)?;
+    for value in &domain_set.leaves {
+        writer.write_u64::<BigEndian>(*value)?;
+    }
+
+    writer.write_i64::<BigEndian>(domain_set.label_bit_map.len() as i64)?;
+    for value in &domain_set.label_bit_map {
+        writer.write_u64::<BigEndian>(*value)?;
+    }
+
+    writer.write_i64::<BigEndian>(domain_set.labels.len() as i64)?;
+    writer.write_all(&domain_set.labels)?;
+    Ok(())
 }
 
 fn parse_from_mrs(buf: &[u8]) -> Result<RulePayload> {
@@ -212,7 +370,7 @@ mod tests {
         let mut file = std::fs::File::open(rules_dir.join("geo/geosite/aliyun.mrs"))?;
         let mut buf = Vec::new();
         file.read_to_end(&mut buf)?;
-        let payload = DomainParseStrategy::parse(&buf, RuleFormat::Mrs)?;
+        let payload = DomainCodecStrategy::parse(&buf, RuleFormat::Mrs)?;
         println!("payload: {:?}", payload);
         Ok(())
     }
@@ -223,7 +381,7 @@ mod tests {
         let mut file = std::fs::File::open(rules_dir.join("geo/geosite/aliyun.yaml"))?;
         let mut buf = Vec::new();
         file.read_to_end(&mut buf)?;
-        let payload = DomainParseStrategy::parse(&buf, RuleFormat::Yaml)?;
+        let payload = DomainCodecStrategy::parse(&buf, RuleFormat::Yaml)?;
         println!("payload: {:?}", payload);
         Ok(())
     }
@@ -234,7 +392,7 @@ mod tests {
         let mut file = std::fs::File::open(rules_dir.join("geo/geosite/aliyun.list"))?;
         let mut buf = Vec::new();
         file.read_to_end(&mut buf)?;
-        let payload = DomainParseStrategy::parse(&buf, RuleFormat::Text)?;
+        let payload = DomainCodecStrategy::parse(&buf, RuleFormat::Text)?;
         println!("payload: {:?}", payload);
         Ok(())
     }

--- a/crates/mihomo-rule-parser/src/domain.rs
+++ b/crates/mihomo-rule-parser/src/domain.rs
@@ -165,11 +165,7 @@ fn expand_rule(rule: &str) -> Result<Vec<String>> {
     let normalized = rule.to_lowercase();
     let parts: Vec<&str> = normalized.split('.').collect();
 
-    if parts.len() == 1 {
-        if parts[0].is_empty() {
-            return Err(RuleParseError::InvalidRule(rule.to_string()));
-        }
-    } else if parts.iter().skip(1).any(|part| part.is_empty()) {
+    if parts.iter().any(|part| part.is_empty()) {
         return Err(RuleParseError::InvalidRule(rule.to_string()));
     }
 

--- a/crates/mihomo-rule-parser/src/domain.rs
+++ b/crates/mihomo-rule-parser/src/domain.rs
@@ -233,9 +233,20 @@ fn prepare_domain_set(rules: &[String]) -> Result<(i64, DomainSet)> {
         return Err(RuleParseError::EmptyRule);
     }
 
+    let mut search_key = String::new();
     let count = keys
         .iter()
-        .filter(|key| key.ends_with(".+") || keys.binary_search(&format!("{key}.+")).is_err())
+        .filter(|key| {
+            if key.ends_with(".+") {
+                return true;
+            }
+
+            search_key.clear();
+            search_key.push_str(key);
+            search_key.push_str(".+");
+
+            keys.binary_search(&search_key).is_err()
+        })
         .count() as i64;
 
     let domain_set = build_domain_set(&keys);

--- a/crates/mihomo-rule-parser/src/domain.rs
+++ b/crates/mihomo-rule-parser/src/domain.rs
@@ -224,12 +224,12 @@ fn export_as_mrs<P: AsRef<Path>>(rules: &[String], file_path: P) -> Result<()> {
 }
 
 fn export_mrs_body<W: Write>(rules: &[String], writer: &mut W) -> Result<i64> {
-    let mut count = 0i64;
+    // let mut count = 0i64;
     let mut keys = Vec::new();
 
     for rule in rules {
         let expanded = expand_rule(rule)?;
-        count += 1;
+        // count += 1;
         keys.extend(expanded.into_iter().map(|domain| reverse_string(&domain)));
     }
 
@@ -239,6 +239,11 @@ fn export_mrs_body<W: Write>(rules: &[String], writer: &mut W) -> Result<i64> {
     if keys.is_empty() {
         return Err(RuleParseError::EmptyRule);
     }
+
+    let count = keys
+        .iter()
+        .filter(|key| key.ends_with(".+") || keys.binary_search(&format!("{key}.+")).is_err())
+        .count() as i64;
 
     let domain_set = build_domain_set(&keys);
     write_domain_set(writer, &domain_set)?;

--- a/crates/mihomo-rule-parser/src/domain.rs
+++ b/crates/mihomo-rule-parser/src/domain.rs
@@ -127,11 +127,11 @@ fn parse_from_mrs(buf: &[u8]) -> Result<RulePayload> {
     let mut reader = zstd::Decoder::new(Cursor::new(buf))?;
 
     // validate mrs file
-    let (actual_behavior, count) = utils::read_mrs_header(&mut reader)?;
-    if actual_behavior != RuleBehavior::Domain {
+    let (behavior, count) = utils::read_mrs_header(&mut reader)?;
+    if behavior != RuleBehavior::Domain {
         return Err(RuleParseError::BehaviorMismatch {
             expected: RuleBehavior::Domain,
-            actual: actual_behavior,
+            actual: behavior,
         });
     }
 

--- a/crates/mihomo-rule-parser/src/domain.rs
+++ b/crates/mihomo-rule-parser/src/domain.rs
@@ -7,7 +7,7 @@ use std::{
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
 use crate::{
-    Codec, RuleBehavior, RuleFormat, RulePayload, bitmap,
+    Codec, MRS_VERSION, RuleBehavior, RuleFormat, RulePayload, bitmap,
     error::{Result, RuleParseError},
     utils,
 };
@@ -140,7 +140,7 @@ fn parse_from_mrs(buf: &[u8]) -> Result<RulePayload> {
     // version
     let mut version = [0u8; 1];
     reader.read_exact(&mut version)?;
-    if version[0] != 1 {
+    if version[0] != MRS_VERSION {
         return Err(RuleParseError::InvalidVersion);
     }
 
@@ -208,22 +208,17 @@ struct QueueItem {
 }
 
 fn export_as_mrs<P: AsRef<Path>>(rules: &[String], file_path: P) -> Result<()> {
-    let mut body = Vec::new();
-    let count = export_mrs_body(rules, &mut body)?;
-
-    let mut encoded = Vec::new();
-    {
-        let mut writer = zstd::Encoder::new(&mut encoded, 0)?;
-        utils::write_mrs_header(&mut writer, RuleBehavior::Domain, count)?;
-        writer.write_all(&body)?;
-        writer.finish()?;
-    }
-
-    std::fs::write(file_path, encoded)?;
+    let (count, domain_set) = prepare_domain_set(rules)?;
+    let file = std::fs::File::create(file_path)?;
+    let buffered = std::io::BufWriter::new(file);
+    let mut writer = zstd::Encoder::new(buffered, 0)?;
+    utils::write_mrs_header(&mut writer, RuleBehavior::Domain, count)?;
+    write_domain_set(&mut writer, &domain_set)?;
+    writer.finish()?;
     Ok(())
 }
 
-fn export_mrs_body<W: Write>(rules: &[String], writer: &mut W) -> Result<i64> {
+fn prepare_domain_set(rules: &[String]) -> Result<(i64, DomainSet)> {
     let mut keys = Vec::new();
 
     for rule in rules {
@@ -244,8 +239,7 @@ fn export_mrs_body<W: Write>(rules: &[String], writer: &mut W) -> Result<i64> {
         .count() as i64;
 
     let domain_set = build_domain_set(&keys);
-    write_domain_set(writer, &domain_set)?;
-    Ok(count)
+    Ok((count, domain_set))
 }
 
 fn expand_rule(rule: &str) -> Result<Vec<String>> {
@@ -321,7 +315,7 @@ fn build_domain_set(keys: &[String]) -> DomainSet {
 }
 
 fn write_domain_set<W: Write>(writer: &mut W, domain_set: &DomainSet) -> Result<()> {
-    writer.write_all(&[1])?;
+    writer.write_all(&[MRS_VERSION])?;
     writer.write_i64::<BigEndian>(domain_set.leaves.len() as i64)?;
     for value in &domain_set.leaves {
         writer.write_u64::<BigEndian>(*value)?;

--- a/crates/mihomo-rule-parser/src/error.rs
+++ b/crates/mihomo-rule-parser/src/error.rs
@@ -21,6 +21,8 @@ pub enum RuleParseError {
     InvalidBehavior(String),
     #[error("invalid rule format: {0}")]
     InvalidFormat(String),
+    #[error("invalid rule: {0}")]
+    InvalidRule(String),
     #[error("behavior mismatch (expected {expected}, got {actual})")]
     BehaviorMismatch {
         expected: RuleBehavior,
@@ -30,4 +32,8 @@ pub enum RuleParseError {
     YamlParseError(#[from] serde_yaml::Error),
     #[error("current {0} unsupported format: {1}")]
     UnsupportedFormat(RuleBehavior, RuleFormat),
+    #[error("empty rule")]
+    EmptyRule,
+    #[error("current {0} unsupported export format: {1}")]
+    UnsupportedExportFormat(RuleBehavior, RuleFormat),
 }

--- a/crates/mihomo-rule-parser/src/error.rs
+++ b/crates/mihomo-rule-parser/src/error.rs
@@ -11,12 +11,12 @@ pub type Result<T> = std::result::Result<T, RuleParseError>;
 pub enum RuleParseError {
     #[error("I/O error: {0}")]
     Io(#[from] io::Error),
-    #[error("invalid magic number")]
-    InvalidMagic,
-    #[error("invalid version")]
-    InvalidVersion,
-    #[error("invalid length: {0}")]
-    InvalidLength(i64),
+    #[error("invalid mrs magic number")]
+    InvalidMRSMagic,
+    #[error("invalid mrs version")]
+    InvalidMRSVersion,
+    #[error("invalid mrs length: {0}")]
+    InvalidMRSLength(i64),
     #[error("invalid rule behavior: {0}")]
     InvalidBehavior(String),
     #[error("invalid rule format: {0}")]

--- a/crates/mihomo-rule-parser/src/ipcidr.rs
+++ b/crates/mihomo-rule-parser/src/ipcidr.rs
@@ -8,7 +8,7 @@ use std::{
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
 use crate::{
-    Codec, RuleBehavior, RuleFormat, RulePayload,
+    Codec, MRS_VERSION, RuleBehavior, RuleFormat, RulePayload,
     error::{Result, RuleParseError},
     utils,
 };
@@ -233,7 +233,7 @@ fn parse_from_mrs(buf: &[u8]) -> Result<RulePayload> {
     // version
     let mut version = [0u8; 1];
     reader.read_exact(&mut version)?;
-    if version[0] != 1 {
+    if version[0] != MRS_VERSION {
         return Err(RuleParseError::InvalidVersion);
     }
 
@@ -265,22 +265,17 @@ fn parse_from_mrs(buf: &[u8]) -> Result<RulePayload> {
 // ------------------------------ Export ------------------------------------
 
 fn export_as_mrs<P: AsRef<Path>>(rules: &[String], file_path: P) -> Result<()> {
-    let mut body = Vec::new();
-    let count = export_mrs_body(rules, &mut body)?;
-
-    let mut encoded = Vec::new();
-    {
-        let mut writer = zstd::Encoder::new(&mut encoded, 0)?;
-        utils::write_mrs_header(&mut writer, RuleBehavior::IpCidr, count)?;
-        writer.write_all(&body)?;
-        writer.finish()?;
-    }
-
-    std::fs::write(file_path, encoded)?;
+    let (count, ranges) = prepare_ranges(rules)?;
+    let file = std::fs::File::create(file_path)?;
+    let buffered = std::io::BufWriter::new(file);
+    let mut writer = zstd::Encoder::new(buffered, 0)?;
+    utils::write_mrs_header(&mut writer, RuleBehavior::IpCidr, count)?;
+    write_ranges(&mut writer, &ranges)?;
+    writer.finish()?;
     Ok(())
 }
 
-pub(crate) fn export_mrs_body<W: Write>(rules: &[String], writer: &mut W) -> Result<i64> {
+fn prepare_ranges(rules: &[String]) -> Result<(i64, Vec<IpRange>)> {
     let mut count = 0i64;
     let mut ranges = Vec::new();
 
@@ -293,14 +288,17 @@ pub(crate) fn export_mrs_body<W: Write>(rules: &[String], writer: &mut W) -> Res
         return Err(RuleParseError::EmptyRule);
     }
 
-    writer.write_all(&[1])?;
+    Ok((count, ranges))
+}
+
+fn write_ranges<W: Write>(writer: &mut W, ranges: &[IpRange]) -> Result<()> {
+    writer.write_all(&[MRS_VERSION])?;
     writer.write_i64::<BigEndian>(ranges.len() as i64)?;
     for range in ranges {
         writer.write_all(&ip_addr_to_mrs_bytes(range.from))?;
         writer.write_all(&ip_addr_to_mrs_bytes(range.to))?;
     }
-
-    Ok(count)
+    Ok(())
 }
 
 fn parse_cidr_rule(rule: &str) -> Result<IpRange> {

--- a/crates/mihomo-rule-parser/src/ipcidr.rs
+++ b/crates/mihomo-rule-parser/src/ipcidr.rs
@@ -215,6 +215,55 @@ impl IpCidrTransform for IpAddr {
     }
 }
 
+// ------------------------------ Parse ------------------------------------
+
+fn parse_from_mrs(buf: &[u8]) -> Result<RulePayload> {
+    // create ZSTD decoder
+    let mut reader = zstd::Decoder::new(Cursor::new(buf))?;
+
+    // validate mrs file
+    let (behavior, count) = utils::read_mrs_header(&mut reader)?;
+    if behavior != RuleBehavior::IpCidr {
+        return Err(RuleParseError::BehaviorMismatch {
+            expected: RuleBehavior::IpCidr,
+            actual: behavior,
+        });
+    }
+
+    // version
+    let mut version = [0u8; 1];
+    reader.read_exact(&mut version)?;
+    if version[0] != 1 {
+        return Err(RuleParseError::InvalidVersion);
+    }
+
+    // length
+    let length = reader.read_i64::<BigEndian>()?;
+    if length < 1 {
+        return Err(RuleParseError::InvalidLength(length));
+    }
+
+    let mut rules: Vec<String> = Vec::new();
+    for _ in 0..length {
+        let mut from = [0u8; 16];
+        reader.read_exact(&mut from)?;
+        let from_addr = IpAddr::addr_from_16(from).unmap();
+
+        let mut to = [0u8; 16];
+        reader.read_exact(&mut to)?;
+        let to_addr = IpAddr::addr_from_16(to).unmap();
+
+        // generate Ip range
+        let range = IpAddr::ip_range(from_addr, to_addr);
+        rules.extend(range.prefixes().into_iter().map(|prefix| prefix.to_string()));
+    }
+    drop(reader);
+
+    Ok(RulePayload { count, rules })
+}
+
+// ------------------------------ Export ------------------------------------
+
 fn export_as_mrs<P: AsRef<Path>>(rules: &[String], file_path: P) -> Result<()> {
     let mut body = Vec::new();
     let count = export_mrs_body(rules, &mut body)?;
@@ -311,44 +360,7 @@ fn ip_addr_to_mrs_bytes(addr: IpAddr) -> [u8; 16] {
     }
 }
 
-fn parse_from_mrs(buf: &[u8]) -> Result<RulePayload> {
-    // create ZSTD decoder
-    let mut reader = zstd::Decoder::new(Cursor::new(buf))?;
-
-    // validate mrs file
-    let count = utils::validate_mrs(&mut reader, RuleBehavior::IpCidr)?;
-
-    // version
-    let mut version = [0u8; 1];
-    reader.read_exact(&mut version)?;
-    if version[0] != 1 {
-        return Err(RuleParseError::InvalidVersion);
-    }
-
-    // length
-    let length = reader.read_i64::<BigEndian>()?;
-    if length < 1 {
-        return Err(RuleParseError::InvalidLength(length));
-    }
-
-    let mut rules: Vec<String> = Vec::new();
-    for _ in 0..length {
-        let mut from = [0u8; 16];
-        reader.read_exact(&mut from)?;
-        let from_addr = IpAddr::addr_from_16(from).unmap();
-
-        let mut to = [0u8; 16];
-        reader.read_exact(&mut to)?;
-        let to_addr = IpAddr::addr_from_16(to).unmap();
-
-        // generate Ip range
-        let range = IpAddr::ip_range(from_addr, to_addr);
-        rules.extend(range.prefixes().into_iter().map(|prefix| prefix.to_string()));
-    }
-    drop(reader);
-
-    Ok(RulePayload { count, rules })
-}
+// ------------------------------ Test ------------------------------------
 
 #[cfg(test)]
 #[allow(deprecated)]

--- a/crates/mihomo-rule-parser/src/ipcidr.rs
+++ b/crates/mihomo-rule-parser/src/ipcidr.rs
@@ -234,13 +234,13 @@ fn parse_from_mrs(buf: &[u8]) -> Result<RulePayload> {
     let mut version = [0u8; 1];
     reader.read_exact(&mut version)?;
     if version[0] != MRS_VERSION {
-        return Err(RuleParseError::InvalidVersion);
+        return Err(RuleParseError::InvalidMRSVersion);
     }
 
     // length
     let length = reader.read_i64::<BigEndian>()?;
     if length < 1 {
-        return Err(RuleParseError::InvalidLength(length));
+        return Err(RuleParseError::InvalidMRSLength(length));
     }
 
     let mut rules: Vec<String> = Vec::new();

--- a/crates/mihomo-rule-parser/src/ipcidr.rs
+++ b/crates/mihomo-rule-parser/src/ipcidr.rs
@@ -1,26 +1,35 @@
 use std::{
     fmt::{Debug, Display},
-    io::{Cursor, Read},
+    io::{Cursor, Read, Write},
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    path::Path,
 };
 
-use byteorder::{BigEndian, ReadBytesExt};
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
 use crate::{
-    Parser, RuleBehavior, RuleFormat, RulePayload,
+    Codec, RuleBehavior, RuleFormat, RulePayload,
     error::{Result, RuleParseError},
     utils,
 };
 
 /// ipcidr parse strategy
-pub(crate) struct IpCidrParseStrategy;
+pub(crate) struct IpCidrCodecStrategy;
 
-impl Parser for IpCidrParseStrategy {
+impl Codec for IpCidrCodecStrategy {
     fn parse(buf: &[u8], format: RuleFormat) -> Result<RulePayload> {
         match format {
             RuleFormat::Mrs => parse_from_mrs(buf),
             RuleFormat::Yaml => utils::parse_from_yaml(buf),
             RuleFormat::Text => utils::parse_from_text(buf),
+        }
+    }
+
+    fn export<P: AsRef<std::path::Path>>(rules: &[String], file_path: P, format: RuleFormat) -> Result<()> {
+        match format {
+            RuleFormat::Mrs => export_as_mrs(rules, file_path),
+            RuleFormat::Yaml => utils::export_as_yaml(rules, file_path),
+            RuleFormat::Text => utils::export_as_text(rules, file_path),
         }
     }
 }
@@ -206,6 +215,112 @@ impl IpCidrTransform for IpAddr {
     }
 }
 
+fn export_as_mrs<P: AsRef<Path>>(rules: &[String], file_path: P) -> Result<()> {
+    let mut body = Vec::new();
+    let count = export_mrs_body(rules, &mut body)?;
+
+    let mut encoded = Vec::new();
+    {
+        let mut writer = zstd::Encoder::new(&mut encoded, 0)?;
+        utils::write_mrs_header(&mut writer, RuleBehavior::IpCidr, count)?;
+        writer.write_all(&body)?;
+        writer.finish()?;
+    }
+
+    std::fs::write(file_path, encoded)?;
+    Ok(())
+}
+
+pub(crate) fn export_mrs_body<W: Write>(rules: &[String], writer: &mut W) -> Result<i64> {
+    let mut count = 0i64;
+    let mut ranges = Vec::new();
+
+    for rule in rules {
+        ranges.push(parse_cidr_rule(rule)?);
+        count += 1;
+    }
+
+    if ranges.is_empty() {
+        return Err(RuleParseError::EmptyRule);
+    }
+
+    writer.write_all(&[1])?;
+    writer.write_i64::<BigEndian>(ranges.len() as i64)?;
+    for range in ranges {
+        writer.write_all(&ip_addr_to_mrs_bytes(range.from))?;
+        writer.write_all(&ip_addr_to_mrs_bytes(range.to))?;
+    }
+
+    Ok(count)
+}
+
+fn parse_cidr_rule(rule: &str) -> Result<IpRange> {
+    let (addr, prefix_len) = rule
+        .trim()
+        .split_once('/')
+        .ok_or_else(|| RuleParseError::InvalidRule(rule.to_string()))?;
+    let prefix_len = prefix_len
+        .parse::<u8>()
+        .map_err(|_| RuleParseError::InvalidRule(rule.to_string()))?;
+    let addr = addr
+        .parse::<IpAddr>()
+        .map_err(|_| RuleParseError::InvalidRule(rule.to_string()))?;
+
+    match addr {
+        IpAddr::V4(ip) => {
+            if prefix_len > 32 {
+                return Err(RuleParseError::InvalidRule(rule.to_string()));
+            }
+            let value = u32::from_be_bytes(ip.octets());
+            let mask = if prefix_len == 0 {
+                0
+            } else {
+                u32::MAX << (32 - u32::from(prefix_len))
+            };
+            let from = value & mask;
+            let size = if prefix_len == 32 {
+                1
+            } else {
+                1u64 << (32 - u32::from(prefix_len))
+            };
+            let to = from as u64 + size - 1;
+            Ok(IpRange {
+                from: IpAddr::V4(Ipv4Addr::from(from)),
+                to: IpAddr::V4(Ipv4Addr::from(to as u32)),
+            })
+        }
+        IpAddr::V6(ip) => {
+            if prefix_len > 128 {
+                return Err(RuleParseError::InvalidRule(rule.to_string()));
+            }
+            let value = u128::from_be_bytes(ip.octets());
+            let mask = if prefix_len == 0 {
+                0
+            } else {
+                u128::MAX << (128 - u32::from(prefix_len))
+            };
+            let from = value & mask;
+            let size = if prefix_len == 128 {
+                1
+            } else {
+                1u128 << (128 - u32::from(prefix_len))
+            };
+            let to = from + size - 1;
+            Ok(IpRange {
+                from: IpAddr::V6(Ipv6Addr::from(from.to_be_bytes())),
+                to: IpAddr::V6(Ipv6Addr::from(to.to_be_bytes())),
+            })
+        }
+    }
+}
+
+fn ip_addr_to_mrs_bytes(addr: IpAddr) -> [u8; 16] {
+    match addr {
+        IpAddr::V4(ip) => ip.to_ipv6_mapped().octets(),
+        IpAddr::V6(ip) => ip.octets(),
+    }
+}
+
 fn parse_from_mrs(buf: &[u8]) -> Result<RulePayload> {
     // create ZSTD decoder
     let mut reader = zstd::Decoder::new(Cursor::new(buf))?;
@@ -299,7 +414,7 @@ mod tests {
         let mut file = std::fs::File::open(rules_dir.join("geo/geoip/ad.mrs"))?;
         let mut buf = Vec::new();
         file.read_to_end(&mut buf)?;
-        let payload = IpCidrParseStrategy::parse(&buf, RuleFormat::Mrs)?;
+        let payload = IpCidrCodecStrategy::parse(&buf, RuleFormat::Mrs)?;
         println!("payload: {:?}", payload);
         Ok(())
     }
@@ -310,7 +425,7 @@ mod tests {
         let mut file = std::fs::File::open(rules_dir.join("geo/geoip/ad.yaml"))?;
         let mut buf = Vec::new();
         file.read_to_end(&mut buf)?;
-        let payload = IpCidrParseStrategy::parse(&buf, RuleFormat::Yaml)?;
+        let payload = IpCidrCodecStrategy::parse(&buf, RuleFormat::Yaml)?;
         println!("payload: {:?}", payload);
         Ok(())
     }
@@ -321,7 +436,7 @@ mod tests {
         let mut file = std::fs::File::open(rules_dir.join("geo/geoip/ad.list"))?;
         let mut buf = Vec::new();
         file.read_to_end(&mut buf)?;
-        let payload = IpCidrParseStrategy::parse(&buf, RuleFormat::Text)?;
+        let payload = IpCidrCodecStrategy::parse(&buf, RuleFormat::Text)?;
         println!("payload: {:?}", payload);
         Ok(())
     }

--- a/crates/mihomo-rule-parser/src/ipcidr.rs
+++ b/crates/mihomo-rule-parser/src/ipcidr.rs
@@ -278,15 +278,10 @@ fn parse_cidr_rule(rule: &str) -> Result<IpRange> {
                 u32::MAX << (32 - u32::from(prefix_len))
             };
             let from = value & mask;
-            let size = if prefix_len == 32 {
-                1
-            } else {
-                1u64 << (32 - u32::from(prefix_len))
-            };
-            let to = from as u64 + size - 1;
+            let to = from | !mask;
             Ok(IpRange {
                 from: IpAddr::V4(Ipv4Addr::from(from)),
-                to: IpAddr::V4(Ipv4Addr::from(to as u32)),
+                to: IpAddr::V4(Ipv4Addr::from(to)),
             })
         }
         IpAddr::V6(ip) => {
@@ -300,12 +295,7 @@ fn parse_cidr_rule(rule: &str) -> Result<IpRange> {
                 u128::MAX << (128 - u32::from(prefix_len))
             };
             let from = value & mask;
-            let size = if prefix_len == 128 {
-                1
-            } else {
-                1u128 << (128 - u32::from(prefix_len))
-            };
-            let to = from + size - 1;
+            let to = from | !mask;
             Ok(IpRange {
                 from: IpAddr::V6(Ipv6Addr::from(from.to_be_bytes())),
                 to: IpAddr::V6(Ipv6Addr::from(to.to_be_bytes())),

--- a/crates/mihomo-rule-parser/src/lib.rs
+++ b/crates/mihomo-rule-parser/src/lib.rs
@@ -1,10 +1,10 @@
 #![allow(dead_code)]
 use std::{fmt::Display, path::Path};
 
-use classical::ClassicalParseStrategy;
-use domain::DomainParseStrategy;
+use classical::ClassicalCodecStrategy;
+use domain::DomainCodecStrategy;
 pub use error::RuleParseError;
-use ipcidr::IpCidrParseStrategy;
+use ipcidr::IpCidrCodecStrategy;
 use serde::{Deserialize, Serialize};
 
 use crate::error::Result;
@@ -100,17 +100,34 @@ impl From<YamlPayload> for RulePayload {
     }
 }
 
-trait Parser {
+/// A trait for encoding and decoding rule payloads.
+trait Codec {
     fn parse(buf: &[u8], format: RuleFormat) -> Result<RulePayload>;
+
+    fn export<P: AsRef<Path>>(rules: &[String], file_path: P, format: RuleFormat) -> Result<()>;
 }
 
 pub fn parse<P: AsRef<Path>>(file_path: P, behavior: RuleBehavior, format: RuleFormat) -> Result<RulePayload> {
     let buf = std::fs::read(file_path)?;
-    let rule = match behavior {
-        RuleBehavior::Domain => DomainParseStrategy::parse(&buf, format)?,
-        RuleBehavior::IpCidr => IpCidrParseStrategy::parse(&buf, format)?,
-        RuleBehavior::Classical => ClassicalParseStrategy::parse(&buf, format)?,
-    };
-    drop(buf);
-    Ok(rule)
+    match behavior {
+        RuleBehavior::Domain => DomainCodecStrategy::parse(&buf, format),
+        RuleBehavior::IpCidr => IpCidrCodecStrategy::parse(&buf, format),
+        RuleBehavior::Classical => ClassicalCodecStrategy::parse(&buf, format),
+    }
+}
+
+pub fn export<P: AsRef<Path>>(
+    rules: &[String],
+    file_path: P,
+    behavior: RuleBehavior,
+    format: RuleFormat,
+) -> Result<()> {
+    if rules.is_empty() {
+        return Err(RuleParseError::EmptyRule);
+    }
+    match behavior {
+        RuleBehavior::Domain => DomainCodecStrategy::export(rules, file_path, format),
+        RuleBehavior::IpCidr => IpCidrCodecStrategy::export(rules, file_path, format),
+        RuleBehavior::Classical => ClassicalCodecStrategy::export(rules, file_path, format),
+    }
 }

--- a/crates/mihomo-rule-parser/src/lib.rs
+++ b/crates/mihomo-rule-parser/src/lib.rs
@@ -16,6 +16,11 @@ mod error;
 mod ipcidr;
 mod utils;
 
+/// MRSv1
+pub(crate) const MRS_MAGIC: [u8; 4] = [b'M', b'R', b'S', 1];
+/// MRS version
+pub(crate) const MRS_VERSION: u8 = 1;
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum RuleBehavior {
     Domain,

--- a/crates/mihomo-rule-parser/src/lib.rs
+++ b/crates/mihomo-rule-parser/src/lib.rs
@@ -21,7 +21,7 @@ pub(crate) const MRS_MAGIC: [u8; 4] = [b'M', b'R', b'S', 1];
 /// MRS version
 pub(crate) const MRS_VERSION: u8 = 1;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
 pub enum RuleBehavior {
     Domain,
     #[serde(rename = "IPCIDR")]

--- a/crates/mihomo-rule-parser/src/utils.rs
+++ b/crates/mihomo-rule-parser/src/utils.rs
@@ -89,19 +89,27 @@ pub(crate) fn parse_from_text(buf: &[u8]) -> Result<RulePayload> {
 }
 
 pub(crate) fn export_as_yaml<P: AsRef<Path>>(rules: &[String], file_path: P) -> Result<()> {
+    let file = std::fs::File::create(file_path)?;
+    let writer = std::io::BufWriter::new(file);
     let payload = YamlPayload {
         payload: rules.to_vec(),
     };
-    let data = serde_yaml::to_string(&payload)?.into_bytes();
-    std::fs::write(file_path, data)?;
+    serde_yaml::to_writer(writer, &payload)?;
     Ok(())
 }
 
 pub(crate) fn export_as_text<P: AsRef<Path>>(rules: &[String], file_path: P) -> Result<()> {
-    let mut data = rules.join("\n").into_bytes();
-    if !data.is_empty() {
-        data.push(b'\n');
+    let file = std::fs::File::create(file_path)?;
+    let mut writer = std::io::BufWriter::new(file);
+    for (i, rule) in rules.iter().enumerate() {
+        if i > 0 {
+            writer.write_all(b"\n")?;
+        }
+        writer.write_all(rule.as_bytes())?;
     }
-    std::fs::write(file_path, data)?;
+    if !rules.is_empty() {
+        writer.write_all(b"\n")?;
+    }
+    writer.flush()?;
     Ok(())
 }

--- a/crates/mihomo-rule-parser/src/utils.rs
+++ b/crates/mihomo-rule-parser/src/utils.rs
@@ -6,12 +6,9 @@ use std::{
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
 use crate::{
-    RuleBehavior, RulePayload, YamlPayload,
+    MRS_MAGIC, RuleBehavior, RulePayload, YamlPayload,
     error::{Result, RuleParseError},
 };
-
-/// MRSv1
-const MRS_MAGIC: [u8; 4] = [b'M', b'R', b'S', 1];
 
 /// Get the rule behavior based on the given behavior byte.
 fn get_rule_behavior(behavior: u8) -> Result<RuleBehavior> {

--- a/crates/mihomo-rule-parser/src/utils.rs
+++ b/crates/mihomo-rule-parser/src/utils.rs
@@ -6,9 +6,8 @@ use std::{
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
 use crate::{
-    RuleBehavior, RuleFormat, RulePayload, YamlPayload, domain,
+    RuleBehavior, RulePayload, YamlPayload,
     error::{Result, RuleParseError},
-    ipcidr,
 };
 
 /// MRSv1
@@ -97,46 +96,15 @@ pub(crate) fn export_as_text<P: AsRef<Path>>(rules: &[String], file_path: P) -> 
     Ok(())
 }
 
-pub(crate) fn export_as_mrs(rules: &[String], behavior: RuleBehavior) -> Result<Vec<u8>> {
-    if rules.is_empty() {
-        return Err(RuleParseError::EmptyRule);
-    }
-
-    let mut body = Vec::new();
-    let count = match behavior {
-        RuleBehavior::Domain => domain::export_mrs_body(rules, &mut body)?,
-        RuleBehavior::IpCidr => ipcidr::export_mrs_body(rules, &mut body)?,
-        RuleBehavior::Classical => {
-            return Err(RuleParseError::UnsupportedExportFormat(
-                RuleBehavior::Classical,
-                RuleFormat::Mrs,
-            ));
-        }
-    };
-
-    let mut encoded = Vec::new();
-    {
-        let mut writer = zstd::Encoder::new(&mut encoded, 0)?;
-        write_mrs_header(&mut writer, behavior, count)?;
-        writer.write_all(&body)?;
-        writer.finish()?;
-    }
-
-    Ok(encoded)
-}
-
 pub(crate) fn write_mrs_header<W: Write>(writer: &mut W, behavior: RuleBehavior, count: i64) -> Result<()> {
     writer.write_all(&MRS_MAGIC)?;
-    writer.write_all(&[behavior_to_byte(behavior)])?;
+    let behavior_byte = match behavior {
+        RuleBehavior::Domain => 0,
+        RuleBehavior::IpCidr => 1,
+        RuleBehavior::Classical => return Err(RuleParseError::InvalidBehavior("classical".to_string())),
+    };
+    writer.write_all(&[behavior_byte])?;
     writer.write_i64::<BigEndian>(count)?;
     writer.write_i64::<BigEndian>(0)?;
     Ok(())
-}
-
-fn behavior_to_byte(behavior: RuleBehavior) -> u8 {
-    match behavior {
-        RuleBehavior::Domain => 0,
-        RuleBehavior::IpCidr => 1,
-        RuleBehavior::Classical => 2,
-    }
 }

--- a/crates/mihomo-rule-parser/src/utils.rs
+++ b/crates/mihomo-rule-parser/src/utils.rs
@@ -10,15 +10,6 @@ use crate::{
     error::{Result, RuleParseError},
 };
 
-/// Get the rule behavior based on the given behavior byte.
-fn get_rule_behavior(behavior: u8) -> Result<RuleBehavior> {
-    match behavior {
-        0 => Ok(RuleBehavior::Domain),
-        1 => Ok(RuleBehavior::IpCidr),
-        _ => Err(RuleParseError::InvalidBehavior("unknown behavior".to_string())),
-    }
-}
-
 /// Validate MRS format and return the count of rules.
 pub(crate) fn read_mrs_header<R: Read>(reader: &mut R) -> Result<(RuleBehavior, i64)> {
     // 读取并校验 Magic Number
@@ -31,7 +22,13 @@ pub(crate) fn read_mrs_header<R: Read>(reader: &mut R) -> Result<(RuleBehavior, 
     // 读取 Behavior
     let mut behavior = [0u8; 1];
     reader.read_exact(&mut behavior)?;
-    let behavior = get_rule_behavior(behavior[0])?;
+    let behavior = match behavior[0] {
+        0 => RuleBehavior::Domain,
+        1 => RuleBehavior::IpCidr,
+        b => {
+            return Err(RuleParseError::InvalidBehavior(format!("unknown behavior: [{b}]")));
+        }
+    };
 
     // 读取 Count
     let count = reader.read_i64::<BigEndian>()?;

--- a/crates/mihomo-rule-parser/src/utils.rs
+++ b/crates/mihomo-rule-parser/src/utils.rs
@@ -1,10 +1,14 @@
-use std::io::{BufRead, BufReader, Read};
+use std::{
+    io::{BufRead, BufReader, Read, Write},
+    path::Path,
+};
 
-use byteorder::{BigEndian, ReadBytesExt};
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
 use crate::{
-    RuleBehavior, RulePayload, YamlPayload,
+    RuleBehavior, RuleFormat, RulePayload, YamlPayload, domain,
     error::{Result, RuleParseError},
+    ipcidr,
 };
 
 /// MRSv1
@@ -76,4 +80,63 @@ pub(crate) fn parse_from_text(buf: &[u8]) -> Result<RulePayload> {
         rules.push(rule?.trim().to_string());
     }
     Ok(RulePayload { count, rules })
+}
+
+pub(crate) fn export_as_yaml<P: AsRef<Path>>(rules: &[String], file_path: P) -> Result<()> {
+    let payload = YamlPayload {
+        payload: rules.to_vec(),
+    };
+    let data = serde_yaml::to_string(&payload)?.into_bytes();
+    std::fs::write(file_path, data)?;
+    Ok(())
+}
+
+pub(crate) fn export_as_text<P: AsRef<Path>>(rules: &[String], file_path: P) -> Result<()> {
+    let data = rules.join("\n").into_bytes();
+    std::fs::write(file_path, data)?;
+    Ok(())
+}
+
+pub(crate) fn export_as_mrs(rules: &[String], behavior: RuleBehavior) -> Result<Vec<u8>> {
+    if rules.is_empty() {
+        return Err(RuleParseError::EmptyRule);
+    }
+
+    let mut body = Vec::new();
+    let count = match behavior {
+        RuleBehavior::Domain => domain::export_mrs_body(rules, &mut body)?,
+        RuleBehavior::IpCidr => ipcidr::export_mrs_body(rules, &mut body)?,
+        RuleBehavior::Classical => {
+            return Err(RuleParseError::UnsupportedExportFormat(
+                RuleBehavior::Classical,
+                RuleFormat::Mrs,
+            ));
+        }
+    };
+
+    let mut encoded = Vec::new();
+    {
+        let mut writer = zstd::Encoder::new(&mut encoded, 0)?;
+        write_mrs_header(&mut writer, behavior, count)?;
+        writer.write_all(&body)?;
+        writer.finish()?;
+    }
+
+    Ok(encoded)
+}
+
+pub(crate) fn write_mrs_header<W: Write>(writer: &mut W, behavior: RuleBehavior, count: i64) -> Result<()> {
+    writer.write_all(&MRS_MAGIC)?;
+    writer.write_all(&[behavior_to_byte(behavior)])?;
+    writer.write_i64::<BigEndian>(count)?;
+    writer.write_i64::<BigEndian>(0)?;
+    Ok(())
+}
+
+fn behavior_to_byte(behavior: RuleBehavior) -> u8 {
+    match behavior {
+        RuleBehavior::Domain => 0,
+        RuleBehavior::IpCidr => 1,
+        RuleBehavior::Classical => 2,
+    }
 }

--- a/crates/mihomo-rule-parser/src/utils.rs
+++ b/crates/mihomo-rule-parser/src/utils.rs
@@ -25,7 +25,7 @@ pub(crate) fn read_mrs_header<R: Read>(reader: &mut R) -> Result<(RuleBehavior, 
     let mut magic = [0u8; 4];
     reader.read_exact(&mut magic)?;
     if magic != MRS_MAGIC {
-        return Err(RuleParseError::InvalidMagic);
+        return Err(RuleParseError::InvalidMRSMagic);
     }
 
     // 读取 Behavior
@@ -39,7 +39,7 @@ pub(crate) fn read_mrs_header<R: Read>(reader: &mut R) -> Result<(RuleBehavior, 
     // 读取 Extra 数据
     let extra_length = reader.read_i64::<BigEndian>()?;
     if extra_length < 0 {
-        return Err(RuleParseError::InvalidLength(extra_length));
+        return Err(RuleParseError::InvalidMRSLength(extra_length));
     }
 
     // for future use

--- a/crates/mihomo-rule-parser/src/utils.rs
+++ b/crates/mihomo-rule-parser/src/utils.rs
@@ -23,7 +23,7 @@ fn get_rule_behavior(behavior: u8) -> Result<RuleBehavior> {
 }
 
 /// Validate MRS format and return the count of rules.
-pub(crate) fn validate_mrs<R: Read>(reader: &mut R, expected_behavior: RuleBehavior) -> Result<i64> {
+pub(crate) fn read_mrs_header<R: Read>(reader: &mut R) -> Result<(RuleBehavior, i64)> {
     // 读取并校验 Magic Number
     let mut magic = [0u8; 4];
     reader.read_exact(&mut magic)?;
@@ -31,16 +31,10 @@ pub(crate) fn validate_mrs<R: Read>(reader: &mut R, expected_behavior: RuleBehav
         return Err(RuleParseError::InvalidMagic);
     }
 
-    // 读取并校验 Behavior
+    // 读取 Behavior
     let mut behavior = [0u8; 1];
     reader.read_exact(&mut behavior)?;
-    let actual_behavior = get_rule_behavior(behavior[0])?;
-    if actual_behavior != expected_behavior {
-        return Err(RuleParseError::BehaviorMismatch {
-            expected: expected_behavior,
-            actual: actual_behavior,
-        });
-    }
+    let behavior = get_rule_behavior(behavior[0])?;
 
     // 读取 Count
     let count = reader.read_i64::<BigEndian>()?;
@@ -60,7 +54,20 @@ pub(crate) fn validate_mrs<R: Read>(reader: &mut R, expected_behavior: RuleBehav
         None
     };
 
-    Ok(count)
+    Ok((behavior, count))
+}
+
+pub(crate) fn write_mrs_header<W: Write>(writer: &mut W, behavior: RuleBehavior, count: i64) -> Result<()> {
+    writer.write_all(&MRS_MAGIC)?;
+    let behavior_byte = match behavior {
+        RuleBehavior::Domain => 0,
+        RuleBehavior::IpCidr => 1,
+        RuleBehavior::Classical => return Err(RuleParseError::InvalidBehavior("classical".to_string())),
+    };
+    writer.write_all(&[behavior_byte])?;
+    writer.write_i64::<BigEndian>(count)?;
+    writer.write_i64::<BigEndian>(0)?;
+    Ok(())
 }
 
 /// Parse YAML format
@@ -91,20 +98,10 @@ pub(crate) fn export_as_yaml<P: AsRef<Path>>(rules: &[String], file_path: P) -> 
 }
 
 pub(crate) fn export_as_text<P: AsRef<Path>>(rules: &[String], file_path: P) -> Result<()> {
-    let data = rules.join("\n").into_bytes();
+    let mut data = rules.join("\n").into_bytes();
+    if !data.is_empty() {
+        data.push(b'\n');
+    }
     std::fs::write(file_path, data)?;
-    Ok(())
-}
-
-pub(crate) fn write_mrs_header<W: Write>(writer: &mut W, behavior: RuleBehavior, count: i64) -> Result<()> {
-    writer.write_all(&MRS_MAGIC)?;
-    let behavior_byte = match behavior {
-        RuleBehavior::Domain => 0,
-        RuleBehavior::IpCidr => 1,
-        RuleBehavior::Classical => return Err(RuleParseError::InvalidBehavior("classical".to_string())),
-    };
-    writer.write_all(&[behavior_byte])?;
-    writer.write_i64::<BigEndian>(count)?;
-    writer.write_i64::<BigEndian>(0)?;
     Ok(())
 }

--- a/crates/mihomo-rule-parser/tests/common/mod.rs
+++ b/crates/mihomo-rule-parser/tests/common/mod.rs
@@ -6,6 +6,7 @@ use std::{
 
 pub fn test_export_path(name: &str, ext: &str) -> Result<PathBuf, Box<dyn std::error::Error>> {
     let dir = std::env::temp_dir().join("mihomo-rule-parser-export-tests");
+    println!("test export dir: {}", dir.display());
     std::fs::create_dir_all(&dir)?;
     Ok(dir.join(format!("{name}.{ext}")))
 }

--- a/crates/mihomo-rule-parser/tests/common/mod.rs
+++ b/crates/mihomo-rule-parser/tests/common/mod.rs
@@ -4,6 +4,12 @@ use std::{
     process::Command,
 };
 
+pub fn test_export_path(name: &str, ext: &str) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let dir = std::env::temp_dir().join("mihomo-rule-parser-export-tests");
+    std::fs::create_dir_all(&dir)?;
+    Ok(dir.join(format!("{name}.{ext}")))
+}
+
 pub fn init_meta_rules() -> Result<PathBuf, Box<dyn std::error::Error>> {
     let tmp_dir = std::env::temp_dir();
     let rules_dir = tmp_dir.join("meta-rules-dat");

--- a/crates/mihomo-rule-parser/tests/parse_test.rs
+++ b/crates/mihomo-rule-parser/tests/parse_test.rs
@@ -143,14 +143,17 @@ fn test_public_export_mrs_method() -> Result<(), Box<dyn Error>> {
     let path = common::test_export_path("rules-mrs", "mrs")?;
     let mut rules = vec![
         "+.example.com".to_string(),
+        "+.example.com".to_string(),
         "www.example.com".to_string(),
         "+.gh.io".to_string(),
     ];
     rules.sort();
+    rules.dedup();
 
     export(&rules, &path, RuleBehavior::Domain, RuleFormat::Mrs)?;
 
     let payload = parse(&path, RuleBehavior::Domain, RuleFormat::Mrs)?;
+    assert_eq!(payload.count, 3);
     assert_eq!(payload.rules, rules);
     Ok(())
 }

--- a/crates/mihomo-rule-parser/tests/parse_test.rs
+++ b/crates/mihomo-rule-parser/tests/parse_test.rs
@@ -250,117 +250,118 @@ fn check_all_mihomo_mrs() -> Result<(), Box<dyn Error>> {
     }
 
     // domain
-    let check_behavior = "domain";
-    let mrs_dir_path = rules_dir.join("geo/geosite");
-    // ipcidr
-    // let check_behavior = "ipcidr";
-    // let mrs_dir_path = rules_dir.join("geo/geoip");
+    let check_behaviors = ["domain", "ipcidr"];
+    let mrs_dir_paths = [rules_dir.join("geo/geosite"), rules_dir.join("geo/geoip")];
 
-    let mrs_dir = std::fs::read_dir(&mrs_dir_path)?;
-    let mut mrs_files = Vec::new();
-    mrs_dir
-        .into_iter()
-        .filter(|entry| {
-            let entry = entry.as_ref().expect("failed to read entry");
-            entry.path().extension().is_some_and(|ext| ext == "mrs")
-        })
-        .for_each(|entry| {
-            let entry = entry.expect("failed to read entry");
-            let path = entry.path();
-            let file_name = path.file_name().expect("failed to get file name");
-            let file_name = file_name.to_str().expect("failed to convert file name to string");
-            mrs_files.push(file_name.to_string());
-        });
+    for (check_behavior, mrs_dir_path) in check_behaviors.into_iter().zip(mrs_dir_paths.into_iter()) {
+        let mrs_dir = std::fs::read_dir(&mrs_dir_path)?;
+        let mut mrs_files = Vec::new();
+        mrs_dir
+            .into_iter()
+            .filter(|entry| {
+                let entry = entry.as_ref().expect("failed to read entry");
+                entry.path().extension().is_some_and(|ext| ext == "mrs")
+            })
+            .for_each(|entry| {
+                let entry = entry.expect("failed to read entry");
+                let path = entry.path();
+                let file_name = path.file_name().expect("failed to get file name");
+                let file_name = file_name.to_str().expect("failed to convert file name to string");
+                mrs_files.push(file_name.to_string());
+            });
 
-    let mihomo_convert_error_file = Arc::new(Mutex::new(Vec::new()));
-    let check_diff_error_file = Arc::new(Mutex::new(Vec::new()));
-    // starting check diff
-    std::thread::scope(|s| {
-        for file_name in &mrs_files {
-            // use mihomo command to convert mrs files to txt files
-            let mrs_file_path = mrs_dir_path.join(file_name);
-            let mihomo_file_path = mihomo_out_dir.join(file_name).with_extension("txt");
+        let mihomo_convert_error_file = Arc::new(Mutex::new(Vec::new()));
+        let check_diff_error_file = Arc::new(Mutex::new(Vec::new()));
+        // starting check diff
+        std::thread::scope(|s| {
+            for file_name in &mrs_files {
+                // use mihomo command to convert mrs files to txt files
+                let mrs_file_path = mrs_dir_path.join(file_name);
+                let mihomo_file_path = mihomo_out_dir.join(file_name).with_extension("txt");
 
-            let rust_out_dir_ = rust_out_dir.clone();
-            let mihomo_convert_error_file_ = mihomo_convert_error_file.clone();
-            let check_diff_error_file_ = check_diff_error_file.clone();
-            s.spawn(move || {
-                #[cfg(windows)]
-                let verge_mihomo_path = r"D:\Clash Verge\self-mihomo.exe";
-                #[cfg(unix)]
-                let verge_mihomo_path = "self-mihomo";
-                let output = std::process::Command::new(verge_mihomo_path)
-                    .args([
-                        "convert-ruleset",
-                        check_behavior,
-                        "mrs",
-                        &mrs_file_path.display().to_string(),
-                        &mihomo_file_path.display().to_string(),
-                    ])
-                    .output()?;
+                let rust_out_dir_ = rust_out_dir.clone();
+                let mihomo_convert_error_file_ = mihomo_convert_error_file.clone();
+                let check_diff_error_file_ = check_diff_error_file.clone();
+                s.spawn(move || {
+                    #[cfg(windows)]
+                    let verge_mihomo_path = r"D:\Clash Verge\self-mihomo.exe";
+                    #[cfg(unix)]
+                    let verge_mihomo_path = "self-mihomo";
+                    let output = std::process::Command::new(verge_mihomo_path)
+                        .args([
+                            "convert-ruleset",
+                            check_behavior,
+                            "mrs",
+                            &mrs_file_path.display().to_string(),
+                            &mihomo_file_path.display().to_string(),
+                        ])
+                        .output()?;
 
-                // use rust to convert mrs files to txt files
-                if output.status.success() {
-                    let behavior = match check_behavior {
-                        "domain" => RuleBehavior::Domain,
-                        "ipcidr" => RuleBehavior::IpCidr,
-                        _ => return Err(RuleParseError::InvalidBehavior(check_behavior.to_string())),
-                    };
-                    let rule_payload = parse(&mrs_file_path, behavior, RuleFormat::Mrs)?;
-                    let rust_file_path = rust_out_dir_.join(file_name).with_extension("txt");
-                    let mut file = std::fs::File::create(&rust_file_path)?;
-                    file.write_all(rule_payload.rules.join("\n").as_bytes())?;
-                    file.sync_all()?;
+                    // use rust to convert mrs files to txt files
+                    if output.status.success() {
+                        let behavior = match check_behavior {
+                            "domain" => RuleBehavior::Domain,
+                            "ipcidr" => RuleBehavior::IpCidr,
+                            _ => return Err(RuleParseError::InvalidBehavior(check_behavior.to_string())),
+                        };
+                        let rule_payload = parse(&mrs_file_path, behavior, RuleFormat::Mrs)?;
+                        let rust_file_path = rust_out_dir_.join(file_name).with_extension("txt");
+                        let mut file = std::fs::File::create(&rust_file_path)?;
+                        file.write_all(rule_payload.rules.join("\n").as_bytes())?;
+                        file.sync_all()?;
 
-                    // check diff file
-                    if let Err(err) = common::check_diff(rust_file_path, mihomo_file_path) {
-                        println!("check diff [{}] error: {}", file_name, err);
-                        check_diff_error_file_.lock().unwrap().push(file_name.clone());
-                    } else {
-                        println!("convert [{}] success", file_name);
-                    }
+                        // check diff file
+                        if let Err(err) = common::check_diff(rust_file_path, mihomo_file_path) {
+                            println!("check diff [{}] error: {}", file_name, err);
+                            check_diff_error_file_.lock().unwrap().push(file_name.clone());
+                        } else {
+                            println!("convert [{}] success", file_name);
+                        }
 
-                    // check export mrs is same as mihomo
-                    let output_file_path = common::test_export_path(&format!("export-{file_name}"), "mrs").unwrap();
-                    export(&rule_payload.rules, &output_file_path, behavior, RuleFormat::Mrs)?;
-                    let e_rule_payload = parse(&output_file_path, behavior, RuleFormat::Mrs)?;
-                    if rule_payload.count != e_rule_payload.count {
-                        println!(
-                            "export mrs count not match, expected: {}, actual: {}",
-                            rule_payload.count, e_rule_payload.count
-                        );
-                    }
-                    for (i, rule) in rule_payload.rules.iter().enumerate() {
-                        if rule != &e_rule_payload.rules[i] {
+                        // check export mrs is same as mihomo
+                        let output_file_path = common::test_export_path(&format!("export-{file_name}"), "mrs").unwrap();
+                        export(&rule_payload.rules, &output_file_path, behavior, RuleFormat::Mrs)?;
+                        let e_rule_payload = parse(&output_file_path, behavior, RuleFormat::Mrs)?;
+                        if rule_payload.count != e_rule_payload.count {
                             println!(
-                                "export mrs rule not match, expected: {}, actual: {}",
-                                rule, e_rule_payload.rules[i]
+                                "export mrs count not match, expected: {}, actual: {}",
+                                rule_payload.count, e_rule_payload.count
                             );
                         }
+                        for (i, rule) in rule_payload.rules.iter().enumerate() {
+                            if rule != &e_rule_payload.rules[i] {
+                                println!(
+                                    "export mrs rule not match, expected: {}, actual: {}",
+                                    rule, e_rule_payload.rules[i]
+                                );
+                            }
+                        }
+                    } else {
+                        println!("mihomo convert [{}] error, output: {:?}", file_name, output);
+                        mihomo_convert_error_file_.lock().unwrap().push(file_name.clone());
                     }
-                } else {
-                    println!("mihomo convert [{}] error, output: {:?}", file_name, output);
-                    mihomo_convert_error_file_.lock().unwrap().push(file_name.clone());
-                }
-                Result::Ok(())
-            });
+                    Result::Ok(())
+                });
+            }
+        });
+        if !mihomo_convert_error_file.lock().unwrap().is_empty() {
+            println!(
+                "\n--------------- [{check_behavior}] mihomo convert error files (skip use rust to convert) -------------------"
+            );
+            println!("{:?}", mihomo_convert_error_file.lock().unwrap());
+            println!("-----------------------------------------------------------------------------------------\n");
         }
-    });
-    if !mihomo_convert_error_file.lock().unwrap().is_empty() {
-        println!("\n--------------- mihomo convert error files (skip use rust to convert) -------------------");
-        println!("{:?}", mihomo_convert_error_file.lock().unwrap());
-        println!("-----------------------------------------------------------------------------------------\n");
-    }
-    if check_diff_error_file.lock().unwrap().is_empty() {
-        println!("\n✅ all convert success!!!");
-    } else {
-        println!("\n------------------- ❌ check diff error files -----------------------");
-        println!("{:?}", check_diff_error_file.lock().unwrap());
-        println!("----------------------------------------------------------------------");
-        return Err(Box::new(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "check diff error",
-        )));
+        if check_diff_error_file.lock().unwrap().is_empty() {
+            println!("\n✅ [{check_behavior}] all convert success!!!");
+        } else {
+            println!("\n------------------- ❌ [{check_behavior}] check diff error files -----------------------");
+            println!("{:?}", check_diff_error_file.lock().unwrap());
+            println!("----------------------------------------------------------------------");
+            return Err(Box::new(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "check diff error",
+            )));
+        }
     }
 
     println!("cost time: {}ms", start.elapsed().as_millis());

--- a/crates/mihomo-rule-parser/tests/parse_test.rs
+++ b/crates/mihomo-rule-parser/tests/parse_test.rs
@@ -319,6 +319,25 @@ fn check_all_mihomo_mrs() -> Result<(), Box<dyn Error>> {
                     } else {
                         println!("convert [{}] success", file_name);
                     }
+
+                    // check export mrs is same as mihomo
+                    let output_file_path = common::test_export_path(&format!("export-{file_name}"), "mrs").unwrap();
+                    export(&rule_payload.rules, &output_file_path, behavior, RuleFormat::Mrs)?;
+                    let e_rule_payload = parse(&output_file_path, behavior, RuleFormat::Mrs)?;
+                    if rule_payload.count != e_rule_payload.count {
+                        println!(
+                            "export mrs count not match, expected: {}, actual: {}",
+                            rule_payload.count, e_rule_payload.count
+                        );
+                    }
+                    for (i, rule) in rule_payload.rules.iter().enumerate() {
+                        if rule != &e_rule_payload.rules[i] {
+                            println!(
+                                "export mrs rule not match, expected: {}, actual: {}",
+                                rule, e_rule_payload.rules[i]
+                            );
+                        }
+                    }
                 } else {
                     println!("mihomo convert [{}] error, output: {:?}", file_name, output);
                     mihomo_convert_error_file_.lock().unwrap().push(file_name.clone());

--- a/crates/mihomo-rule-parser/tests/parse_test.rs
+++ b/crates/mihomo-rule-parser/tests/parse_test.rs
@@ -5,7 +5,7 @@ use std::{
     time::Instant,
 };
 
-use mihomo_rule_parser::{RuleBehavior, RuleFormat, RuleParseError, parse};
+use mihomo_rule_parser::{RuleBehavior, RuleFormat, RuleParseError, export, parse};
 
 mod common;
 
@@ -103,6 +103,95 @@ fn test_public_parse_method() -> Result<(), Box<dyn Error>> {
     file.sync_all()?;
     println!("check file: {}", text_file_path.display());
 
+    Ok(())
+}
+
+#[test]
+fn test_public_export_yaml_method() -> Result<(), Box<dyn Error>> {
+    let path = common::test_export_path("rules-yaml", "yaml")?;
+    let rules = vec!["example.com".to_string(), "sub.example.com".to_string()];
+
+    export(&rules, &path, RuleBehavior::Domain, RuleFormat::Yaml)?;
+
+    let payload = parse(&path, RuleBehavior::Domain, RuleFormat::Yaml)?;
+    assert_eq!(payload.rules, rules);
+    Ok(())
+}
+
+#[test]
+fn test_public_export_text_method() -> Result<(), Box<dyn Error>> {
+    let path = common::test_export_path("rules-text", "list")?;
+    let rules = vec!["192.168.0.0/16".to_string(), "10.0.0.0/8".to_string()];
+
+    export(&rules, &path, RuleBehavior::IpCidr, RuleFormat::Text)?;
+
+    let payload = parse(&path, RuleBehavior::IpCidr, RuleFormat::Text)?;
+    assert_eq!(payload.rules, rules);
+    Ok(())
+}
+
+#[test]
+fn test_public_export_mrs_method() -> Result<(), Box<dyn Error>> {
+    let path = common::test_export_path("rules-mrs", "mrs")?;
+    let rules = vec!["+.example.com".to_string(), "www.example.com".to_string()];
+
+    export(&rules, &path, RuleBehavior::Domain, RuleFormat::Mrs)?;
+
+    let payload = parse(&path, RuleBehavior::Domain, RuleFormat::Mrs)?;
+    assert_eq!(payload.rules, rules);
+    Ok(())
+}
+
+#[test]
+fn test_public_export_ipcidr_mrs_method() -> Result<(), Box<dyn Error>> {
+    let path = common::test_export_path("ipcidr-rules-mrs", "mrs")?;
+    let rules = vec!["192.168.0.0/16".to_string(), "10.0.0.0/8".to_string()];
+
+    export(&rules, &path, RuleBehavior::IpCidr, RuleFormat::Mrs)?;
+
+    let payload = parse(&path, RuleBehavior::IpCidr, RuleFormat::Mrs)?;
+    assert_eq!(payload.rules, rules);
+    Ok(())
+}
+
+#[test]
+fn test_public_export_classical_mrs_method() -> Result<(), Box<dyn Error>> {
+    let path = common::test_export_path("classical-rules-mrs", "mrs")?;
+    let rules = vec!["DOMAIN,example.com".to_string()];
+
+    let result = export(&rules, &path, RuleBehavior::Classical, RuleFormat::Mrs);
+    assert!(matches!(
+        result,
+        Err(RuleParseError::UnsupportedExportFormat(
+            RuleBehavior::Classical,
+            RuleFormat::Mrs
+        ))
+    ));
+    Ok(())
+}
+
+#[test]
+fn test_public_export_invalid_domain_mrs_method() -> Result<(), Box<dyn Error>> {
+    let path = common::test_export_path("invalid-domain-rules-mrs", "mrs")?;
+    let rules = vec!["example.com/24".to_string()];
+
+    let result = export(&rules, &path, RuleBehavior::Domain, RuleFormat::Mrs);
+    assert!(matches!(
+        result,
+        Err(RuleParseError::InvalidRule(rule)) if rule == "example.com/24"
+    ));
+    Ok(())
+}
+
+#[test]
+fn test_public_export_ipv6_mrs_method() -> Result<(), Box<dyn Error>> {
+    let path = common::test_export_path("ipv6-rules-mrs", "mrs")?;
+    let rules = vec!["2001:db8::/126".to_string(), "2001:db8:1::/48".to_string()];
+
+    export(&rules, &path, RuleBehavior::IpCidr, RuleFormat::Mrs)?;
+
+    let payload = parse(&path, RuleBehavior::IpCidr, RuleFormat::Mrs)?;
+    assert_eq!(payload.rules, rules);
     Ok(())
 }
 
@@ -221,6 +310,10 @@ fn check_all_mihomo_mrs() -> Result<(), Box<dyn Error>> {
         println!("\n------------------- ❌ check diff error files -----------------------");
         println!("{:?}", check_diff_error_file.lock().unwrap());
         println!("----------------------------------------------------------------------");
+        return Err(Box::new(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "check diff error",
+        )));
     }
 
     println!("cost time: {}ms", start.elapsed().as_millis());

--- a/crates/mihomo-rule-parser/tests/parse_test.rs
+++ b/crates/mihomo-rule-parser/tests/parse_test.rs
@@ -109,7 +109,11 @@ fn test_public_parse_method() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_public_export_yaml_method() -> Result<(), Box<dyn Error>> {
     let path = common::test_export_path("rules-yaml", "yaml")?;
-    let rules = vec!["example.com".to_string(), "sub.example.com".to_string()];
+    let rules = vec![
+        "example.com".to_string(),
+        "sub.example.com".to_string(),
+        "+.example.com".to_string(),
+    ];
 
     export(&rules, &path, RuleBehavior::Domain, RuleFormat::Yaml)?;
 
@@ -121,7 +125,11 @@ fn test_public_export_yaml_method() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_public_export_text_method() -> Result<(), Box<dyn Error>> {
     let path = common::test_export_path("rules-text", "list")?;
-    let rules = vec!["192.168.0.0/16".to_string(), "10.0.0.0/8".to_string()];
+    let rules = vec![
+        "192.168.0.0/16".to_string(),
+        "10.0.0.0/8".to_string(),
+        "2a03:5640:f572::/47".to_string(),
+    ];
 
     export(&rules, &path, RuleBehavior::IpCidr, RuleFormat::Text)?;
 
@@ -133,7 +141,12 @@ fn test_public_export_text_method() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_public_export_mrs_method() -> Result<(), Box<dyn Error>> {
     let path = common::test_export_path("rules-mrs", "mrs")?;
-    let rules = vec!["+.example.com".to_string(), "www.example.com".to_string()];
+    let mut rules = vec![
+        "+.example.com".to_string(),
+        "www.example.com".to_string(),
+        "+.gh.io".to_string(),
+    ];
+    rules.sort();
 
     export(&rules, &path, RuleBehavior::Domain, RuleFormat::Mrs)?;
 
@@ -145,7 +158,11 @@ fn test_public_export_mrs_method() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_public_export_ipcidr_mrs_method() -> Result<(), Box<dyn Error>> {
     let path = common::test_export_path("ipcidr-rules-mrs", "mrs")?;
-    let rules = vec!["192.168.0.0/16".to_string(), "10.0.0.0/8".to_string()];
+    let rules = vec![
+        "192.168.0.0/16".to_string(),
+        "2a03:5640:f572::/47".to_string(),
+        "10.0.0.0/8".to_string(),
+    ];
 
     export(&rules, &path, RuleBehavior::IpCidr, RuleFormat::Mrs)?;
 
@@ -157,7 +174,11 @@ fn test_public_export_ipcidr_mrs_method() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_public_export_classical_mrs_method() -> Result<(), Box<dyn Error>> {
     let path = common::test_export_path("classical-rules-mrs", "mrs")?;
-    let rules = vec!["DOMAIN,example.com".to_string()];
+    let rules = vec![
+        "DOMAIN-KEYWORD,example".to_string(),
+        "DOMAIN-SUFFIX,example.com".to_string(),
+        "IP-CIDR,203.18.105.0/24".to_string(),
+    ];
 
     let result = export(&rules, &path, RuleBehavior::Classical, RuleFormat::Mrs);
     assert!(matches!(
@@ -186,7 +207,11 @@ fn test_public_export_invalid_domain_mrs_method() -> Result<(), Box<dyn Error>> 
 #[test]
 fn test_public_export_ipv6_mrs_method() -> Result<(), Box<dyn Error>> {
     let path = common::test_export_path("ipv6-rules-mrs", "mrs")?;
-    let rules = vec!["2001:db8::/126".to_string(), "2001:db8:1::/48".to_string()];
+    let rules = vec![
+        "2001:db8::/126".to_string(),
+        "2001:db8:1::/48".to_string(),
+        "2001:67c:4e8::/48".to_string(),
+    ];
 
     export(&rules, &path, RuleBehavior::IpCidr, RuleFormat::Mrs)?;
 


### PR DESCRIPTION
- Added export method to Codec trait for all rule types
- Implemented MRS export for domain and IP CIDR rules
- Added validation for empty rules and invalid formats
- Enhanced error handling with new error types
- Updated classical parser to reject unsupported export formats
- Added comprehensive tests for export functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增公开导出接口，支持 YAML、纯文本与 MRS 二进制格式；域名与 IP/CIDR 支持导出为 MRS。
* **改进**
  * 统一解析/导出实现并简化对外调用，导出流程对格式与输入做校验（空输入/非法规则会报错）。
  * 引入 MRS 读写工具以改进二进制头部处理与行为校验。
* **错误**
  * 增加更细化的错误类型以区分空输入、非法规则与不支持的导出格式。
* **测试**
  * 添加导出相关单元测试并新增导出路径测试辅助工具。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oomeow/clash-verge-self/pull/2045)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->