### PR TITLE
refactor(script): replace boa_engine with rquickjs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,15 +52,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aligned-vec"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
-dependencies = [
- "equator",
-]
-
-[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,12 +175,6 @@ checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-broadcast"
@@ -578,147 +563,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "boa_ast"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6339a700715bda376f5ea65c76e8fe8fc880930d8b0638cea68e7f3da6538e0a"
-dependencies = [
- "bitflags 2.11.1",
- "boa_interner",
- "boa_macros",
- "boa_string",
- "indexmap 2.14.0",
- "num-bigint",
- "rustc-hash",
-]
-
-[[package]]
-name = "boa_engine"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1521be326f8a5c8887e95d4ce7f002917a002a23f7b93b9a6a2bf50ed4157824"
-dependencies = [
- "aligned-vec",
- "arrayvec",
- "bitflags 2.11.1",
- "boa_ast",
- "boa_gc",
- "boa_interner",
- "boa_macros",
- "boa_parser",
- "boa_string",
- "bytemuck",
- "cfg-if",
- "cow-utils",
- "dashmap 6.1.0",
- "dynify",
- "fast-float2",
- "float16",
- "futures-channel",
- "futures-concurrency",
- "futures-lite 2.6.1",
- "hashbrown 0.16.1",
- "icu_normalizer",
- "indexmap 2.14.0",
- "intrusive-collections",
- "itertools 0.14.0",
- "num-bigint",
- "num-integer",
- "num-traits",
- "num_enum",
- "paste",
- "portable-atomic",
- "rand 0.9.4",
- "regress",
- "rustc-hash",
- "ryu-js",
- "serde",
- "serde_json",
- "small_btree",
- "static_assertions",
- "tag_ptr",
- "tap",
- "thin-vec",
- "thiserror 2.0.18",
- "time",
- "xsum",
-]
-
-[[package]]
-name = "boa_gc"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17323a98cf2e631afacf1a6d659c1212c48a68bacfa85afab0a66ade80582e51"
-dependencies = [
- "boa_macros",
- "boa_string",
- "hashbrown 0.16.1",
- "thin-vec",
-]
-
-[[package]]
-name = "boa_interner"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20510b8b02bcde9b0a01cf34c0c308c56156503d1d91cdab4c8cfbd292b747ea"
-dependencies = [
- "boa_gc",
- "boa_macros",
- "hashbrown 0.16.1",
- "indexmap 2.14.0",
- "once_cell",
- "phf 0.13.1",
- "rustc-hash",
- "static_assertions",
-]
-
-[[package]]
-name = "boa_macros"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5822cb4f146d243060e588bc5a5f2e709683fdad3d7111f42c48e6b5c921d23d"
-dependencies = [
- "cfg-if",
- "cow-utils",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "synstructure",
-]
-
-[[package]]
-name = "boa_parser"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd957fa9fa93e3a001a8aba5a5cd40c2bbfde486378be4c4b472fd304aaddb"
-dependencies = [
- "bitflags 2.11.1",
- "boa_ast",
- "boa_interner",
- "boa_macros",
- "fast-float2",
- "icu_properties",
- "num-bigint",
- "num-traits",
- "regress",
- "rustc-hash",
-]
-
-[[package]]
-name = "boa_string"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2da1d7f4a76fd9040788a122f0d807910800a7b86f5952e9244848c36511de"
-dependencies = [
- "fast-float2",
- "itoa",
- "paste",
- "rustc-hash",
- "ryu-js",
- "static_assertions",
-]
-
-[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,20 +604,6 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
-dependencies = [
- "bytemuck_derive",
-]
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "byteorder"
@@ -1039,7 +869,6 @@ version = "2.3.0"
 dependencies = [
  "anyhow",
  "auto-launch",
- "boa_engine",
  "chrono",
  "clash-verge-self-service",
  "clash-verge-self-utils",
@@ -1057,6 +886,7 @@ dependencies = [
  "reqwest",
  "reqwest_dav",
  "rfd 0.17.2",
+ "rquickjs",
  "runas",
  "rust-i18n",
  "serde",
@@ -1274,12 +1104,6 @@ dependencies = [
  "core-foundation 0.10.1",
  "libc",
 ]
-
-[[package]]
-name = "cow-utils"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
 
 [[package]]
 name = "cpubits"
@@ -1507,20 +1331,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1568,7 +1378,7 @@ dependencies = [
  "autocfg",
  "concat-idents",
  "cron_clock",
- "dashmap 5.5.3",
+ "dashmap",
  "event-listener 5.3.0",
  "futures",
  "log",
@@ -1851,26 +1661,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "dynify"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81acb15628a3e22358bf73de5e7e62360b8a777dbcb5fc9ac7dfa9ae73723747"
-dependencies = [
- "dynify-macros",
-]
-
-[[package]]
-name = "dynify-macros"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec431cd708430d5029356535259c5d645d60edd3d39c54e5eea9782d46caa7d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1926,26 +1716,6 @@ name = "enumflags2_derive"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "equator"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
-dependencies = [
- "equator-macro",
-]
-
-[[package]]
-name = "equator-macro"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2022,12 +1792,6 @@ dependencies = [
  "event-listener 5.3.0",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "fast-float2"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
 
 [[package]]
 name = "fastrand"
@@ -2135,16 +1899,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "float16"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bffafbd079d520191c7c2779ae9cf757601266cf4167d3f659ff09617ff8483"
-dependencies = [
- "cfg-if",
- "rustc_version 0.2.3",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2227,19 +1981,6 @@ checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
-]
-
-[[package]]
-name = "futures-concurrency"
-version = "7.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
-dependencies = [
- "fixedbitset",
- "futures-core",
- "futures-lite 2.6.1",
- "pin-project",
- "smallvec",
 ]
 
 [[package]]
@@ -3061,8 +2802,6 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "write16",
  "zerovec",
 ]
 
@@ -3250,15 +2989,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "intrusive-collections"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
-dependencies = [
- "memoffset 0.9.1",
-]
-
-[[package]]
 name = "io-lifetimes"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3326,15 +3056,6 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -4001,17 +3722,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
- "serde",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4026,15 +3736,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -4496,12 +4197,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4812,12 +4507,6 @@ dependencies = [
  "opaque-debug",
  "universal-hash",
 ]
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -5216,13 +4905,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "regress"
-version = "0.10.5"
+name = "relative-path"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2057b2325e68a893284d1538021ab90279adac1139957ca2a74426c6f118fb48"
+checksum = "bca40a312222d8ba74837cb474edef44b37f561da5f773981007a10bbaa992b0"
 dependencies = [
- "hashbrown 0.16.1",
- "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -5354,6 +5042,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rquickjs"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a"
+dependencies = [
+ "rquickjs-core",
+]
+
+[[package]]
+name = "rquickjs-core"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1"
+dependencies = [
+ "hashbrown 0.16.1",
+ "relative-path",
+ "rquickjs-sys",
+]
+
+[[package]]
+name = "rquickjs-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "rs-snowflake"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5409,7 +5126,7 @@ dependencies = [
  "arc-swap",
  "base62",
  "globwalk",
- "itertools 0.11.0",
+ "itertools",
  "lazy_static",
  "normpath",
  "proc-macro2",
@@ -5583,12 +5300,6 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
-name = "ryu-js"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
 
 [[package]]
 name = "same-file"
@@ -6139,15 +5850,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
-name = "small_btree"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ba60d2df92ba73864714808ca68c059734853e6ab722b40e1cf543ebb3a057a"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6255,12 +5957,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
@@ -6421,12 +6117,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tag_ptr"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0e973b34477b7823833469eb0f5a3a60370fef7a453e02d751b59180d0a5a05"
-
-[[package]]
 name = "tao"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6476,12 +6166,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -7066,12 +6750,6 @@ dependencies = [
  "vtparse",
  "winapi",
 ]
-
-[[package]]
-name = "thin-vec"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "259cdf8ed4e4aca6f1e9d011e10bd53f524a2d0637d7b28450f6c64ac298c4c6"
 
 [[package]]
 name = "thiserror"
@@ -7821,12 +7499,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -9102,12 +8774,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9234,12 +8900,6 @@ name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
-
-[[package]]
-name = "xsum"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0637d3a5566a82fa5214bae89087bc8c9fb94cd8e8a3c07feb691bb8d9c632db"
 
 [[package]]
 name = "yoke"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -54,6 +54,7 @@ tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-deep-link = "2"
+rquickjs = "0.11.0"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-global-shortcut = "2"
@@ -65,7 +66,7 @@ dunce = "1.0"
 nanoid = "0.5"
 chrono = {version = "0.4", features = ["serde"] }
 sysinfo = "0.39"
-boa_engine = "0.21"
+
 delay_timer = "0.11"
 auto-launch = "0.6"
 percent-encoding = "2.3"

--- a/src-tauri/src/cmds/profile.rs
+++ b/src-tauri/src/cmds/profile.rs
@@ -130,16 +130,16 @@ pub async fn delete_profile(uid: String) -> CommandResult<()> {
 pub async fn patch_profiles_config(profiles: IProfiles) -> CommandResult<()> {
     into_command_result(
         async {
-            let switch_current = profiles.current.is_some();
+            let current_changed = profiles.current.is_some();
             Config::profiles().draft().patch_config(profiles)?;
 
             match CoreManager::global().update_config().await {
                 Ok(_) => {
                     Config::profiles().apply();
                     Config::profiles().data().save_file()?;
-                    if switch_current {
+                    if current_changed {
                         tauri::async_runtime::spawn(async {
-                            tracing::debug!("change current profile, run activate selected node");
+                            tracing::debug!("current profile changed, run activate selected nodes work");
                             log_err!(crate::config::activate_selected_nodes().await);
                         });
                     }

--- a/src-tauri/src/enhance/script.rs
+++ b/src-tauri/src/enhance/script.rs
@@ -14,8 +14,6 @@ var console = Object.freeze({
   debug(data){ __verge_log_messages.push({ method: "debug", data: [JSON.stringify(data)], exception: null }); },
 });"#;
 
-const MAIN_RETURN_ERROR: &str = "main function should return object";
-
 pub fn use_script(script: String, config: Mapping) -> Result<(Mapping, Vec<LogMessage>)> {
     use rquickjs::{Context, Runtime};
 
@@ -101,7 +99,7 @@ fn parse_script_result(
     outputs: std::sync::Arc<std::sync::Mutex<Vec<LogMessage>>>,
 ) -> Result<(Mapping, Vec<LogMessage>)> {
     if result.is_null() {
-        anyhow::bail!(MAIN_RETURN_ERROR);
+        anyhow::bail!("main function should return object");
     }
 
     let mut out = outputs.lock().unwrap();

--- a/src-tauri/src/enhance/script.rs
+++ b/src-tauri/src/enhance/script.rs
@@ -1,5 +1,3 @@
-use std::sync::{Arc, Mutex};
-
 use anyhow::Result;
 use serde_yaml::Mapping;
 
@@ -18,7 +16,7 @@ pub fn use_script(script: String, config: Mapping) -> Result<(Mapping, Vec<LogMe
     use rquickjs::{Context, Runtime};
 
     let config = use_lowercase(config);
-    let outputs = Arc::new(Mutex::new(vec![]));
+    let mut outputs = Vec::new();
 
     // Pre-serialize config so it can be injected into JS as a literal
     let config_str = serde_json::to_string(&config)?;
@@ -64,12 +62,10 @@ pub fn use_script(script: String, config: Mapping) -> Result<(Mapping, Vec<LogMe
 
     match serde_json::from_str::<Vec<LogMessage>>(&logs_str) {
         Ok(mut msgs) => {
-            let mut out = outputs.lock().unwrap();
-            out.append(&mut msgs);
+            outputs.append(&mut msgs);
         }
         Err(err) => {
-            let mut out = outputs.lock().unwrap();
-            out.push(LogMessage {
+            outputs.push(LogMessage {
                 method: "error".into(),
                 data: vec![],
                 exception: Some(err.to_string()),
@@ -96,22 +92,21 @@ pub fn use_script(script: String, config: Mapping) -> Result<(Mapping, Vec<LogMe
 fn parse_script_result(
     result: serde_json::Value,
     fallback_config: Mapping,
-    outputs: std::sync::Arc<std::sync::Mutex<Vec<LogMessage>>>,
+    mut outputs: Vec<LogMessage>,
 ) -> Result<(Mapping, Vec<LogMessage>)> {
     if result.is_null() {
         anyhow::bail!("main function should return object");
     }
 
-    let mut out = outputs.lock().unwrap();
     match serde_json::from_value::<Mapping>(result) {
-        Ok(config) => Ok((use_lowercase(config), out.to_vec())),
+        Ok(config) => Ok((use_lowercase(config), outputs)),
         Err(err) => {
-            out.push(LogMessage {
+            outputs.push(LogMessage {
                 method: "error".into(),
                 data: vec![],
                 exception: Some(err.to_string()),
             });
-            Ok((fallback_config, out.to_vec()))
+            Ok((fallback_config, outputs))
         }
     }
 }

--- a/src-tauri/src/enhance/script.rs
+++ b/src-tauri/src/enhance/script.rs
@@ -1,19 +1,26 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
 use serde_yaml::Mapping;
 
 use super::use_lowercase;
 use crate::enhance::LogMessage;
 
 const CONSOLE_SCRIPT: &str = r#"var __verge_log_messages = [];
+function __verge_serialize_log_args(args) {
+  return args.map((item) => JSON.stringify(item));
+}
 var console = Object.freeze({
-  log(data){ __verge_log_messages.push({ method: "log", data: [JSON.stringify(data)], exception: null }); },
-  info(data){ __verge_log_messages.push({ method: "info", data: [JSON.stringify(data)], exception: null }); },
-  error(data){ __verge_log_messages.push({ method: "error", data: [JSON.stringify(data)], exception: null }); },
-  debug(data){ __verge_log_messages.push({ method: "debug", data: [JSON.stringify(data)], exception: null }); },
+  log(...data){ __verge_log_messages.push({ method: "log", data: __verge_serialize_log_args(data), exception: null }); },
+  info(...data){ __verge_log_messages.push({ method: "info", data: __verge_serialize_log_args(data), exception: null }); },
+  error(...data){ __verge_log_messages.push({ method: "error", data: __verge_serialize_log_args(data), exception: null }); },
+  debug(...data){ __verge_log_messages.push({ method: "debug", data: __verge_serialize_log_args(data), exception: null }); },
 });"#;
 
 pub fn use_script(script: String, config: Mapping) -> Result<(Mapping, Vec<LogMessage>)> {
     use rquickjs::{Context, Runtime};
+
+    if !script.contains("function main(") {
+        bail!("Script does not contain main function");
+    }
 
     let config = use_lowercase(config);
     let mut outputs = Vec::new();
@@ -30,13 +37,11 @@ pub fn use_script(script: String, config: Mapping) -> Result<(Mapping, Vec<LogMe
             // Provide a simple console implementation that stores logs in a JS array
             ctx.eval::<(), _>(CONSOLE_SCRIPT)?;
 
-            // Evaluate the user script (syntax/runtime errors here will surface)
-            ctx.eval::<(), _>(script.as_str())?;
-
-            // Call main(...) wrapped in try/catch to normalize runtime exceptions into a JSON result
+            // Evaluate the user script, then call main(...) wrapped in try/catch to normalize runtime exceptions into a JSON result
             let call = format!(
                 r#"(function() {{
                     try {{
+                        {}
                         return JSON.stringify({{ ok: true, value: main({}) }});
                     }} catch (e) {{
                         let name = e && e.name ? e.name : null;
@@ -45,6 +50,7 @@ pub fn use_script(script: String, config: Mapping) -> Result<(Mapping, Vec<LogMe
                         return JSON.stringify({{ ok: false, error: errstr }});
                     }}
                 }})()"#,
+                script.as_str(),
                 config_str
             );
 

--- a/src-tauri/src/enhance/script.rs
+++ b/src-tauri/src/enhance/script.rs
@@ -1,95 +1,111 @@
+use std::sync::{Arc, Mutex};
+
 use anyhow::Result;
 use serde_yaml::Mapping;
 
 use super::use_lowercase;
 use crate::enhance::LogMessage;
 
-const CONSOLE_SCRIPT: &str = r#"var console = Object.freeze({
-  log(data){__verge_log__("log",JSON.stringify(data))},
-  info(data){__verge_log__("info",JSON.stringify(data))},
-  error(data){__verge_log__("error",JSON.stringify(data))},
-  debug(data){__verge_log__("debug",JSON.stringify(data))},
+const CONSOLE_SCRIPT: &str = r#"var __verge_log_messages = [];
+var console = Object.freeze({
+  log(data){ __verge_log_messages.push({ method: "log", data: [JSON.stringify(data)], exception: null }); },
+  info(data){ __verge_log_messages.push({ method: "info", data: [JSON.stringify(data)], exception: null }); },
+  error(data){ __verge_log_messages.push({ method: "error", data: [JSON.stringify(data)], exception: null }); },
+  debug(data){ __verge_log_messages.push({ method: "debug", data: [JSON.stringify(data)], exception: null }); },
 });"#;
 
 const MAIN_RETURN_ERROR: &str = "main function should return object";
 
 pub fn use_script(script: String, config: Mapping) -> Result<(Mapping, Vec<LogMessage>)> {
-    use std::sync::{Arc, Mutex};
+    use rquickjs::{Context, Runtime};
 
     let config = use_lowercase(config);
     let outputs = Arc::new(Mutex::new(vec![]));
-    let mut context = create_context(outputs.clone())?;
 
-    eval_script(&mut context, &script)?;
-
+    // Pre-serialize config so it can be injected into JS as a literal
     let config_str = serde_json::to_string(&config)?;
-    let result = eval_script(&mut context, &format!("main({config_str})"))?;
-    parse_script_result(result, &mut context, config, outputs)
-}
 
-fn create_context(outputs: std::sync::Arc<std::sync::Mutex<Vec<LogMessage>>>) -> Result<boa_engine::Context> {
-    use boa_engine::{Context, JsValue, native_function::NativeFunction};
+    let rt = Runtime::new()?;
+    let ctx = Context::full(&rt)?;
 
-    let mut context = Context::default();
-    let copy_outputs = outputs.clone();
+    // Run script and call `main` inside the JS context. Capture the call result as a JSON string and parse it.
+    let call_str: String = ctx
+        .with(|ctx| {
+            // Provide a simple console implementation that stores logs in a JS array
+            ctx.eval::<(), _>(CONSOLE_SCRIPT)?;
 
-    unsafe {
-        let _ = context.register_global_builtin_callable(
-            "__verge_log__".into(),
-            2,
-            NativeFunction::from_closure(move |_: &JsValue, args: &[JsValue], context: &mut Context| {
-                let level = args.first().unwrap().to_string(context)?;
-                let level = level.to_std_string().unwrap();
-                let data = args.get(1).unwrap().to_string(context)?;
-                let data = data.to_std_string().unwrap();
-                let mut out = copy_outputs.lock().unwrap();
-                out.push(LogMessage {
-                    method: level,
-                    data: vec![data],
-                    exception: None,
-                });
-                Ok(JsValue::undefined())
-            }),
-        );
+            // Evaluate the user script (syntax/runtime errors here will surface)
+            ctx.eval::<(), _>(script.as_str())?;
+
+            // Call main(...) wrapped in try/catch to normalize runtime exceptions into a JSON result
+            let call = format!(
+                r#"(function() {{
+                    try {{
+                        return JSON.stringify({{ ok: true, value: main({}) }});
+                    }} catch (e) {{
+                        let name = e && e.name ? e.name : null;
+                        let msg = e && e.message ? e.message : null;
+                        let errstr = name && msg ? (name + ': ' + msg) : (e && e.stack ? e.stack : String(e));
+                        return JSON.stringify({{ ok: false, error: errstr }});
+                    }}
+                }})()"#,
+                config_str
+            );
+
+            let res_str: String = ctx.eval::<String, _>(call.as_str())?;
+            Ok(res_str)
+        })
+        .map_err(|e: rquickjs::Error| anyhow::anyhow!(e.to_string()))?;
+
+    let call_result: serde_json::Value = serde_json::from_str(&call_str).map_err(|e| anyhow::anyhow!(e.to_string()))?;
+
+    // Collect console logs from JS global array into outputs
+    let logs_str: String = ctx
+        .with(|ctx| ctx.eval::<String, _>("typeof __verge_log_messages !== 'undefined' ? JSON.stringify(__verge_log_messages) : JSON.stringify([])"))
+        .map_err(|e: rquickjs::Error| anyhow::anyhow!(e.to_string()))?;
+
+    match serde_json::from_str::<Vec<LogMessage>>(&logs_str) {
+        Ok(mut msgs) => {
+            let mut out = outputs.lock().unwrap();
+            out.append(&mut msgs);
+        }
+        Err(err) => {
+            let mut out = outputs.lock().unwrap();
+            out.push(LogMessage {
+                method: "error".into(),
+                data: vec![],
+                exception: Some(err.to_string()),
+            });
+        }
     }
 
-    eval_script(&mut context, CONSOLE_SCRIPT)?;
-    Ok(context)
-}
+    // If `main` threw an exception, return it as an error
+    if let Some(ok) = call_result.get("ok").and_then(|v| v.as_bool())
+        && !ok
+    {
+        let err_str = call_result
+            .get("error")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Unknown error")
+            .to_string();
+        anyhow::bail!(err_str);
+    }
 
-fn eval_script(context: &mut boa_engine::Context, source: &str) -> Result<boa_engine::JsValue> {
-    use boa_engine::Source;
-
-    context
-        .eval(Source::from_bytes(source))
-        .map_err(|err| anyhow::anyhow!(js_error_message(err, context)))
-}
-
-fn js_error_message(err: boa_engine::JsError, context: &mut boa_engine::Context) -> String {
-    err.to_opaque(context)
-        .to_string(context)
-        .ok()
-        .and_then(|message| message.to_std_string().ok())
-        .unwrap_or_else(|| err.to_string())
+    let value = call_result.get("value").cloned().unwrap_or(serde_json::Value::Null);
+    parse_script_result(value, config, outputs)
 }
 
 fn parse_script_result(
-    result: boa_engine::JsValue,
-    context: &mut boa_engine::Context,
+    result: serde_json::Value,
     fallback_config: Mapping,
     outputs: std::sync::Arc<std::sync::Mutex<Vec<LogMessage>>>,
 ) -> Result<(Mapping, Vec<LogMessage>)> {
-    if result.is_null() || result.is_undefined() {
+    if result.is_null() {
         anyhow::bail!(MAIN_RETURN_ERROR);
     }
 
-    let json = result
-        .to_json(context)
-        .map_err(|err| anyhow::anyhow!(js_error_message(err, context)))?
-        .ok_or_else(|| anyhow::anyhow!(MAIN_RETURN_ERROR))?;
-
     let mut out = outputs.lock().unwrap();
-    match serde_json::from_value::<Mapping>(json) {
+    match serde_json::from_value::<Mapping>(result) {
         Ok(config) => Ok((use_lowercase(config), out.to_vec())),
         Err(err) => {
             out.push(LogMessage {


### PR DESCRIPTION
将 `src-tauri/src/enhance/script.rs` 的 JS 引擎从 `boa_engine` 替换为 `rquickjs`。主要改动：

- 使用 `rquickjs::Runtime` + `Context` 执行脚本，并通过 try/catch 返回 JSON 结果以统一处理运行时异常。
- 在 JS 端通过全局数组 `__verge_log_messages` 收集 `console` 输出，Rust 端取出并反序列化为 `LogMessage`。
- 更新 `src-tauri/Cargo.toml`（添加 `rquickjs`，移除 `boa_engine`）并更新 `Cargo.lock`。

合并建议：合并前可运行 CI 验证或根据需要调整语法错误处理以保持与既有行为一致。

替换前：每次切换配置文件或重新激活配置时，boa运行每个启用的脚步后，都会导致内存升高
替换后：只有少量的内存升高，远比使用boa的少