### PR TITLE
refactor(proxy): improve global mode rendering and sidebar visibility

### DIFF
--- a/src/components/proxy/proxy-group-sidebar.tsx
+++ b/src/components/proxy/proxy-group-sidebar.tsx
@@ -18,6 +18,7 @@ export const ProxyGroupSidebar = memo(function ProxyGroupSidebar(props: Props) {
   const { groupNameList, onGroupNameClick, className } = props;
   const [open, setOpen] = useState(false);
   const groupNameListWithShortName: GroupName[] = useMemo(() => {
+    if (groupNameList.length === 0) return [];
     return groupNameList.map((name) => {
       let shortName = name.substring(0, 4);
       const regex = RegExp(/^.*[\u4e00-\u9fa5a-zA-Z0-9\s]+$/);

--- a/src/components/proxy/proxy-groups.tsx
+++ b/src/components/proxy/proxy-groups.tsx
@@ -15,7 +15,7 @@ import { ProxyRender } from "@/components/proxy/proxy-render";
 import LoadingPage from "@/pages/loading";
 import delayManager from "@/services/delay";
 import { useProfilesStore, useVergeStore } from "@/stores";
-import { cn, findAndHighlightElement } from "@/utils";
+import { findAndHighlightElement } from "@/utils";
 import { groupId, proxyId } from "@/utils/proxyId";
 
 import {
@@ -276,10 +276,7 @@ export const ProxyGroups = (props: Props) => {
 
   return (
     <Box className="relative flex h-full w-full">
-      <Box
-        className={cn("h-full w-full", {
-          "pr-8": true,
-        })}>
+      <Box className="h-full w-full pr-8">
         <StickyVirtualList
           ref={stickyListRef}
           className="h-full w-full"

--- a/src/components/proxy/proxy-groups.tsx
+++ b/src/components/proxy/proxy-groups.tsx
@@ -38,7 +38,6 @@ export const ProxyGroups = (props: Props) => {
   const { mode } = props;
   const { t } = useTranslation();
   const isDirectMode = mode === "direct";
-  const isRuleMode = mode === "rule";
 
   const { renderList, onProxies } = useRenderList(mode);
   const timeout = useVergeStore((s) => s.verge.default_latency_timeout ?? 5000);
@@ -279,7 +278,7 @@ export const ProxyGroups = (props: Props) => {
     <Box className="relative flex h-full w-full">
       <Box
         className={cn("h-full w-full", {
-          "pr-8": isRuleMode,
+          "pr-8": true,
         })}>
         <StickyVirtualList
           ref={stickyListRef}
@@ -294,16 +293,14 @@ export const ProxyGroups = (props: Props) => {
         />
       </Box>
 
-      {isRuleMode && (
-        <div className="absolute top-0 right-0 bottom-0 z-10 mr-0 w-8 bg-transparent transition-all duration-100 hover:w-30">
-          <ProxyGroupSidebar
-            groupNameList={groupNameList}
-            onGroupNameClick={(groupName) => {
-              handleGroupLocation(groupName);
-            }}
-          />
-        </div>
-      )}
+      <div className="absolute top-0 right-0 bottom-0 z-10 mr-0 w-8 bg-transparent transition-all duration-100 hover:w-30">
+        <ProxyGroupSidebar
+          groupNameList={groupNameList}
+          onGroupNameClick={(groupName) => {
+            handleGroupLocation(groupName);
+          }}
+        />
+      </div>
     </Box>
   );
 };

--- a/src/components/proxy/use-render-list.ts
+++ b/src/components/proxy/use-render-list.ts
@@ -12,6 +12,8 @@ import {
 
 import { filterSort } from "./use-filter-sort";
 
+const EMPTY_HEAD_STATES: Record<string, HeadState> = {};
+
 export enum RenderType {
   GROUP_HEADER = 0,
   PROXY_ITEM = 1,
@@ -75,11 +77,12 @@ export const useRenderList = (mode: string) => {
   const renderList: IRenderItem[] = useMemo(() => {
     if (!proxiesData) return [];
 
-    // global 和 direct 使用展开的样式
-    const useRule = mode === "rule" || mode === "script";
+    // global 模式下将 GLOBAL 代理组置为首位
+    const isGlobalMode = mode === "global";
     const groups = proxiesData.groups.filter((group) => !group.hidden);
-    const renderGroups =
-      (useRule && groups.length ? groups : [proxiesData.global!]) || [];
+    const renderGroups = isGlobalMode
+      ? [proxiesData.global, ...groups]
+      : groups;
 
     const retList = renderGroups.flatMap((group) => {
       const headState = headStates[group.name] || DEFAULT_STATE;
@@ -87,7 +90,7 @@ export const useRenderList = (mode: string) => {
         { type: RenderType.GROUP_HEADER, key: group.name, group, headState },
       ];
 
-      if (headState?.open || !useRule) {
+      if (headState?.open) {
         const proxies = filterSort(
           group.all,
           group.name,
@@ -121,7 +124,7 @@ export const useRenderList = (mode: string) => {
         return ret.concat(
           proxies.map((proxy) => ({
             type: RenderType.PROXY_ITEM,
-            key: `${group.name}-${proxy!.name}`,
+            key: `${group.name}-${proxy.name}`,
             group,
             proxy,
             headState,
@@ -131,7 +134,6 @@ export const useRenderList = (mode: string) => {
       return ret;
     });
 
-    if (!useRule) return retList.slice(1);
     return retList;
   }, [headStates, proxiesData, mode, col]);
 
@@ -140,8 +142,6 @@ export const useRenderList = (mode: string) => {
     onProxies: mutateProxies,
   };
 };
-
-const EMPTY_HEAD_STATES: Record<string, HeadState> = {};
 
 function groupList<T = any>(list: T[], size: number): T[][] {
   return list.reduce((p, n) => {

--- a/src/components/proxy/use-render-list.ts
+++ b/src/components/proxy/use-render-list.ts
@@ -82,7 +82,9 @@ export const useRenderList = (mode: string) => {
     const groups = proxiesData.groups.filter((group) => !group.hidden);
     const renderGroups = isGlobalMode
       ? [proxiesData.global, ...groups]
-      : groups;
+      : groups.length > 0
+        ? groups
+        : [proxiesData.global];
 
     const retList = renderGroups.flatMap((group) => {
       const headState = headStates[group.name] || DEFAULT_STATE;

--- a/src/pages/proxies.tsx
+++ b/src/pages/proxies.tsx
@@ -64,7 +64,7 @@ const ProxyPage = () => {
           </ButtonGroup>
         </Box>
       }>
-      <ProxyGroups mode={curMode!} />
+      <ProxyGroups mode={curMode} />
     </BasePage>
   );
 };

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -41,7 +41,7 @@ export const calcuProxies = async () => {
     if (each?.name !== "GLOBAL" && each?.all) {
       acc.push({
         ...each,
-        all: each.all!.map((item) => generateItem(item)),
+        all: each.all.map((item) => generateItem(item)),
       });
     }
 
@@ -55,7 +55,7 @@ export const calcuProxies = async () => {
       if (proxyRecord[name]?.all) {
         acc.push({
           ...proxyRecord[name],
-          all: proxyRecord[name].all!.map((item) => generateItem(item)),
+          all: proxyRecord[name].all.map((item) => generateItem(item)),
         });
       }
       return acc;
@@ -76,7 +76,7 @@ export const calcuProxies = async () => {
   );
 
   const _global: IProxyGroupItem = {
-    ...global!,
+    ...global,
     all: global?.all?.map((item) => generateItem(item)) || [],
   };
 


### PR DESCRIPTION
When the clash mode is global, render all proxy groups, including the `GLOBAL` group, and this group must be at the top level

<img width="1187" height="862" alt="截屏2026-06-21 20 42 00" src="https://github.com/user-attachments/assets/31338fe1-e60d-4472-9a11-000eafee1970" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化代理分组列表的显示与展开逻辑，提升在不同模式下的浏览一致性。
  * 代理分组侧边栏现在会始终显示，并保留悬停展开与点击定位功能。
  * 修复空分组数据时的处理，避免出现不必要的列表计算。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->