### PR TITLE
fix(delay): provider proxies delay check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@
 ### 🐛 Bug Fixes
 
 - 修复节点激活流程中的重试机制（activate_selected_nodes），提升稳定性
+- 修复 provider 节点延迟检测

--- a/src/components/proxy/proxy-groups.tsx
+++ b/src/components/proxy/proxy-groups.tsx
@@ -146,10 +146,8 @@ export const ProxyGroups = (props: Props) => {
         )
         .flatMap((e) => e.proxyCol || e.proxy!)
         .filter(Boolean);
-      const names = proxies
-        .filter((p) => p.type !== "Direct")
-        .map((p) => p.name);
-      await delayManager.checkListDelay(names, groupName, timeout);
+      const delayProxies = proxies.filter((p) => p.type !== "Direct");
+      await delayManager.checkListDelay(delayProxies, groupName, timeout);
       onProxies();
     },
     { wait: 1000 },

--- a/src/components/proxy/proxy-item-mini.tsx
+++ b/src/components/proxy/proxy-item-mini.tsx
@@ -36,8 +36,13 @@ export const ProxyItemMini = memo(function ProxyItemMini(props: Props) {
   );
   const delay = delayManager.getDelayFix(proxy, group.name);
 
-  const onDelay = async () => {
-    await delayManager.checkDelay(proxy.name, group.name, timeout);
+  const onDelay = async (providerName?: string) => {
+    await delayManager.checkDelay(
+      proxy.name,
+      group.name,
+      timeout,
+      providerName,
+    );
   };
 
   return (
@@ -190,7 +195,7 @@ export const ProxyItemMini = memo(function ProxyItemMini(props: Props) {
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              onDelay();
+              onDelay(proxy.providerName);
             }}>
             Check
           </Box>
@@ -203,7 +208,7 @@ export const ProxyItemMini = memo(function ProxyItemMini(props: Props) {
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              onDelay();
+              onDelay(proxy.providerName);
             }}
             style={{ color: delayManager.formatDelayColor(delay, timeout) }}>
             {delayManager.formatDelay(delay, timeout)}

--- a/src/components/proxy/proxy-item.tsx
+++ b/src/components/proxy/proxy-item.tsx
@@ -46,8 +46,13 @@ export const ProxyItem = memo(function ProxyItem(props: Props) {
   );
   const delay = delayManager.getDelayFix(proxy, group.name);
 
-  const onDelay = useLockFn(async () => {
-    await delayManager.checkDelay(proxy.name, group.name, timeout);
+  const onDelay = useLockFn(async (providerName?: string) => {
+    await delayManager.checkDelay(
+      proxy.name,
+      group.name,
+      timeout,
+      providerName,
+    );
   });
 
   return (
@@ -189,7 +194,7 @@ export const ProxyItem = memo(function ProxyItem(props: Props) {
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                onDelay();
+                onDelay(proxy.providerName);
               }}>
               Check
             </Box>
@@ -202,7 +207,7 @@ export const ProxyItem = memo(function ProxyItem(props: Props) {
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                onDelay();
+                onDelay(proxy.providerName);
               }}
               style={{ color: delayManager.formatDelayColor(delay, timeout) }}>
               {delayManager.formatDelay(delay, timeout)}

--- a/src/services/delay.ts
+++ b/src/services/delay.ts
@@ -1,4 +1,9 @@
-import { delayGroup, delayProxyByName, Proxy } from "tauri-plugin-mihomo-api";
+import {
+  delayGroup,
+  delayProxyByName,
+  healthcheckNodeInProvider,
+  Proxy,
+} from "tauri-plugin-mihomo-api";
 
 export const DEFAULT_TEST_URL = "https://www.gstatic.com/generate_204";
 export const DEFAULT_LATENCY_TIMEOUT = 5000;
@@ -81,13 +86,35 @@ class DelayManager {
     return -1;
   }
 
-  async checkDelay(name: string, group: string, timeout: number) {
+  // 统一延迟测试检测
+  async unifiedDelayCheck(
+    name: string,
+    url: string,
+    timeout: number,
+    providerName?: string,
+  ) {
+    if (providerName)
+      return healthcheckNodeInProvider(providerName, name, url, timeout);
+    return delayProxyByName(name, url, timeout);
+  }
+
+  async checkDelay(
+    name: string,
+    group: string,
+    timeout: number,
+    providerName?: string,
+  ) {
     let delay: number;
     this.setDelay(name, group, -2);
 
     try {
       const url = this.getUrl(group);
-      const result = await delayProxyByName(name, url, timeout);
+      const result = await this.unifiedDelayCheck(
+        name,
+        url,
+        timeout,
+        providerName,
+      );
       delay = result.delay;
     } catch {
       delay = 1e6; // error
@@ -98,12 +125,12 @@ class DelayManager {
   }
 
   async checkListDelay(
-    nameList: string[],
+    proxies: Proxy[],
     group: string,
     timeout: number,
     concurrency = 36,
   ) {
-    const names = nameList.filter(Boolean);
+    const names = proxies.map((o) => o.name).filter(Boolean);
     // 设置正在延迟测试中
     names.forEach((name) => this.setDelay(name, group, -2));
 
@@ -133,10 +160,15 @@ class DelayManager {
     return new Promise((resolve) => {
       const help = async (): Promise<void> => {
         if (current >= concurrency) return;
-        const task = names.shift();
-        if (!task) return;
+        const curProxy = proxies.shift();
+        if (!curProxy) return;
         current += 1;
-        await this.checkDelay(task, group, timeout);
+        await this.checkDelay(
+          curProxy.name,
+          group,
+          timeout,
+          curProxy.providerName,
+        );
         current -= 1;
         total -= 1;
         if (total <= 0) resolve(null);


### PR DESCRIPTION
Relate: https://github.com/MetaCubeX/mihomo/commit/85c1798f7dad757620dcbcc5c7b5c9cc7d02836e break(restful api): restore original Clash /proxies behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能改进**
  * 优化延迟检测：支持按代理所属提供商进行校验，触发“Check/延迟显示”时会按当前代理的提供商重新计算。
  * 批量“测全部延迟”现在跳过直连节点，并基于代理对象执行更准确的延迟检测。
* **问题修复**
  * 修复了 provider 节点的延迟检测异常，提升不同来源代理下的兼容性与结果准确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->